### PR TITLE
Update for new VIAF search API response (#10)

### DIFF
--- a/viapy/api.py
+++ b/viapy/api.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 from attrdict import AttrMap
@@ -66,14 +67,13 @@ class ViafAPI(object):
         search_url = "%s/search" % self.api_base
         params = {
             "query": query,
-            "httpAccept": "application/json",
-            "maximumRecords": 50,  # TODO: configurable ?
+            "maximumRecords": 10,  # TODO: configurable ?
             # sort by number of holdings (default sort on web search)
             # - so better known names show up first
-            "sortKeys": "holdingscount",
+            "sortKey": "holdingscount",
         }
 
-        response = requests.get(search_url, params=params)
+        response = requests.get(search_url, params=params, headers={"Accept": "application/json"})
         logger.debug(
             "search '%s': %s %s, %0.2f",
             params["query"],
@@ -183,13 +183,31 @@ class SRUResult(object):
     @cached_property
     def total_results(self):
         """number of records matching the query"""
-        return int(self._data.get("numberOfRecords", 0))
+        return int(self._data.get("numberOfRecords", {}).get("content", 0))
 
     @cached_property
     def records(self):
-        """list of results as :class:`SRUItem`."""
-        return [SRUItem(d["record"]) for d in self._data.get("records", [])]
+        """List of results as :class:`SRUItem`."""
+        record_or_records = self._data.get("records", {}).get("record")
+        if isinstance(record_or_records, dict):
+            return [SRUItem(self.normalize_record(record_or_records))]
+        elif isinstance(record_or_records, list):
+            return [SRUItem(self.normalize_record(d)) for d in record_or_records]
+        return []
 
+    def normalize_record(self, data):
+        """Records from VIAF now have namespaced keys that increase per result,
+        ns1, ns2, ns3, and so on, which apply to most subkeys (ns2:VIAFCluster,
+        ns2:Document, etc). This method strips all nsX: prefixes recursively"""
+        if isinstance(data, dict):
+            return {
+                re.sub(r"^ns\d+:", "", key): self.normalize_record(value)
+                for key, value in data.items()
+            }
+        elif isinstance(data, list):
+            return [self.normalize_record(item) for item in data]
+        else:
+            return data
 
 class SRUItem(AttrMap):
     """Single item returned by a SRU search, for use with
@@ -198,22 +216,22 @@ class SRUItem(AttrMap):
     @property
     def uri(self):
         """VIAF URI for this result"""
-        return self.recordData.Document["@about"]
+        return self.recordData.VIAFCluster.Document["about"]
 
     @property
     def viaf_id(self):
         """VIAF numeric identifier"""
-        return self.recordData.viafID
+        return self.recordData.VIAFCluster.viafID
 
     @property
     def nametype(self):
         """type of name (personal, corporate, title, etc)"""
-        return self.recordData.nameType
+        return self.recordData.VIAFCluster.nameType
 
     @property
     def label(self):
         """first main heading for this item"""
         try:
-            return self.recordData.mainHeadings.data[0].text
-        except KeyError:
-            return self.recordData.mainHeadings.data.text
+            return self.recordData.VIAFCluster.mainHeadings.data[0].text
+        except (KeyError, IndexError):
+            return self.recordData.VIAFCluster.mainHeadings.data.text

--- a/viapy/api.py
+++ b/viapy/api.py
@@ -132,9 +132,8 @@ class ViafEntity(object):
         graph = rdflib.Graph()
         # 2025 update: Accept header now required, so use requests.get to retrieve RDF
         response = requests.get(self.uri, headers={"Accept": "application/rdf+xml"})
-        if response.status_code == requests.codes.ok:
-            graph.parse(data=response.text, format="xml")
-        response.raise_for_status()
+        response.raise_for_status()  # raise HTTPError on non-success status
+        graph.parse(data=response.text, format="xml")
         logger.debug("Loaded VIAF RDF %s: %0.2f sec", self.uri, time.time() - start)
         return graph
 

--- a/viapy/api.py
+++ b/viapy/api.py
@@ -130,7 +130,11 @@ class ViafEntity(object):
         """VIAF data for this entity as :class:`rdflib.Graph`"""
         start = time.time()
         graph = rdflib.Graph()
-        graph.parse(self.uri)
+        # 2025 update: Accept header now required, so use requests.get to retrieve RDF
+        response = requests.get(self.uri, headers={"Accept": "application/rdf+xml"})
+        if response.status_code == requests.codes.ok:
+            graph.parse(data=response.text, format="xml")
+        response.raise_for_status()
         logger.debug("Loaded VIAF RDF %s: %0.2f sec", self.uri, time.time() - start)
         return graph
 

--- a/viapy/api.py
+++ b/viapy/api.py
@@ -196,8 +196,9 @@ class SRUResult(object):
         return []
 
     def normalize_record(self, data):
-        """Records from VIAF now have namespaced keys that increase per result,
-        ns1, ns2, ns3, and so on, which apply to most subkeys (ns2:VIAFCluster,
+        """Added in May 2025 to match updates to the /search API records, where
+        the JSON response now uses namespaced keys that increase per result:
+        ns2, ns3, ns4, and so on, applying to most subkeys (ns2:VIAFCluster,
         ns2:Document, etc). This method strips all nsX: prefixes recursively"""
         if isinstance(data, dict):
             return {
@@ -211,7 +212,10 @@ class SRUResult(object):
 
 class SRUItem(AttrMap):
     """Single item returned by a SRU search, for use with
-    :meth:`ViafAPI.search` and :class:`SRUResult`."""
+    :meth:`ViafAPI.search` and :class:`SRUResult`.
+    
+    The `VIAFCluster` attribute was added to each property lookup in 2025 to
+    match updates to the /search API's JSON response."""
 
     @property
     def uri(self):

--- a/viapy/tests/fixtures/sru_search.json
+++ b/viapy/tests/fixtures/sru_search.json
@@ -1,679 +1,23179 @@
-
-{"searchRetrieveResponse": {
-    "version":"1.1",
-    "numberOfRecords":"13",
-    "resultSetIdleTime":"1",
-        "records":[
-        
-            {"record":{
-            "recordSchema":"http://viaf.org/VIAFCluster",
-            "recordPacking":"json",
-            
-            "recordData":{
-  "@xmlns": "http://viaf.org/viaf/terms#",
-  "@xmlns:foaf": "http://xmlns.com/foaf/0.1/",
-  "@xmlns:owl": "http://www.w3.org/2002/07/owl#",
-  "@xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-  "@xmlns:void": "http://rdfs.org/ns/void#",
-  "viafID": "888145424579886830405",
-  "Document":   {
-    "@about": "http://viaf.org/viaf/888145424579886830405/",
-    "inDataset": {"@resource": "http://viaf.org/viaf/data"},
-    "primaryTopic": {"@resource": "http://viaf.org/viaf/888145424579886830405"}
-  },
-  "nameType": "UniformTitleExpression",
-  "sources": {"source":   {
-    "@nsid": "VIAFEXP7587557",
-    "#text": "XR|VIAFEXP7587557"
-  }},
-  "length": "11",
-  "mainHeadings":   {
-    "data":     {
-      "text": "Benét, Stephen Vincent, 1898-1943. | John Brown's Body | Russian 1979",
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP7587557"
-      }
-    },
-    "mainHeadingEl":     {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "100",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
-          },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "0",
-            "#text": "(viaf)100260717"
-          },
-                    {
-            "@code": "t",
-            "#text": "John Brown's Body"
-          },
-                    {
-            "@code": "l",
-            "#text": "Russian"
-          },
-                    {
-            "@code": "f",
-            "#text": "1979"
-          }
-        ]
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP7587557"
-      },
-      "id": "XR|VIAFEXP7587557"
-    }
-  },
-  "fixed": {"gender": "u"},
-  "x400s": {"x400":   {
-    "datafield":     {
-      "@ind1": "1",
-      "@ind2": " ",
-      "@tag": "400",
-      "@dtype": "MARC21",
-      "subfield":       [
-                {
-          "@code": "a",
-          "#text": "Benét, Stephen Vincent,"
-        },
-                {
-          "@code": "d",
-          "#text": "1898-1943."
-        },
-                {
-          "@code": "t",
-          "#text": "Telo Dzhona Brauna"
-        },
-                {
-          "@code": "f",
-          "#text": "1979"
-        }
-      ],
-      "normalized": "benet stephen vincent 1898 1943 telo dzhona brauna 1979"
-    },
-    "sources":     {
-      "s": "XR",
-      "sid": "XR|VIAFEXP7587557"
-    }
-  }},
-  "birthDate": "0",
-  "deathDate": "0",
-  "dateType": "lived",
-  "languageOfEntity": {"data":   {
-    "text": "rus",
-    "sources": {"s": "XR"}
-  }},
-  "titles":   {
-    "author":     {
-      "@id": "VIAF|100260717",
-      "text": "Benét, Stephen Vincent"
-    },
-    "work":     {
-      "@id": "VIAF|309266498",
-      "title": "John Brown's Body"
-    }
-  },
-  "history": {"ht":   {
-    "@recid": "XR|VIAFEXP7587557",
-    "@time": "2016-01-31T03:09:58.725288+00:00"
-  }},
-  "creationtime": "2017-08-13T09:13:51.363139+00:00"
-}
-            }}
-            ,
-            {"record":{
-            "recordSchema":"http://viaf.org/VIAFCluster",
-            "recordPacking":"json",
-            
-            "recordData":{
-  "@xmlns": "http://viaf.org/viaf/terms#",
-  "@xmlns:foaf": "http://xmlns.com/foaf/0.1/",
-  "@xmlns:owl": "http://www.w3.org/2002/07/owl#",
-  "@xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-  "@xmlns:void": "http://rdfs.org/ns/void#",
-  "viafID": "291145424547286830715",
-  "Document":   {
-    "@about": "http://viaf.org/viaf/291145424547286830715/",
-    "inDataset": {"@resource": "http://viaf.org/viaf/data"},
-    "primaryTopic": {"@resource": "http://viaf.org/viaf/291145424547286830715"}
-  },
-  "nameType": "UniformTitleExpression",
-  "sources": {"source":   {
-    "@nsid": "VIAFEXP31637671",
-    "#text": "XR|VIAFEXP31637671"
-  }},
-  "length": "11",
-  "mainHeadings":   {
-    "data":     {
-      "text": "Benét, Stephen Vincent, 1898-1943. | America | Turkish 1953",
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP31637671"
-      }
-    },
-    "mainHeadingEl":     {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "100",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
-          },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "0",
-            "#text": "(viaf)100260717"
-          },
-                    {
-            "@code": "t",
-            "#text": "America"
-          },
-                    {
-            "@code": "l",
-            "#text": "Turkish"
-          },
-                    {
-            "@code": "f",
-            "#text": "1953"
-          }
-        ]
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP31637671"
-      },
-      "id": "XR|VIAFEXP31637671"
-    }
-  },
-  "fixed": {"gender": "u"},
-  "x400s": {"x400":   {
-    "datafield":     {
-      "@ind1": "1",
-      "@ind2": " ",
-      "@tag": "400",
-      "@dtype": "MARC21",
-      "subfield":       [
-                {
-          "@code": "a",
-          "#text": "Benét, Stephen Vincent,"
-        },
-                {
-          "@code": "d",
-          "#text": "1898-1943."
-        },
-                {
-          "@code": "t",
-          "#text": "Amerika"
-        },
-                {
-          "@code": "f",
-          "#text": "1953"
-        }
-      ],
-      "normalized": "benet stephen vincent 1898 1943 amerika 1953"
-    },
-    "sources":     {
-      "s": "XR",
-      "sid": "XR|VIAFEXP31637671"
-    }
-  }},
-  "birthDate": "0",
-  "deathDate": "0",
-  "dateType": "lived",
-  "languageOfEntity": {"data":   {
-    "text": "tur",
-    "sources": {"s": "XR"}
-  }},
-  "titles":   {
-    "author":     {
-      "@id": "VIAF|100260717",
-      "text": "Benét, Stephen Vincent"
-    },
-    "work":     {
-      "@id": "VIAF|307979935",
-      "title": "America"
-    }
-  },
-  "history": {"ht":   {
-    "@recid": "XR|VIAFEXP31637671",
-    "@time": "2016-01-31T03:04:32.352032+00:00"
-  }},
-  "creationtime": "2017-08-13T08:55:38.996915+00:00"
-}
-            }}
-            ,
-            {"record":{
-            "recordSchema":"http://viaf.org/VIAFCluster",
-            "recordPacking":"json",
-            
-            "recordData":{
-  "@xmlns": "http://viaf.org/viaf/terms#",
-  "@xmlns:foaf": "http://xmlns.com/foaf/0.1/",
-  "@xmlns:owl": "http://www.w3.org/2002/07/owl#",
-  "@xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-  "@xmlns:void": "http://rdfs.org/ns/void#",
-  "viafID": "316264350",
-  "Document":   {
-    "@about": "http://viaf.org/viaf/316264350/",
-    "inDataset": {"@resource": "http://viaf.org/viaf/data"},
-    "primaryTopic": {"@resource": "http://viaf.org/viaf/316264350"}
-  },
-  "nameType": "UniformTitleExpression",
-  "sources": {"source":   {
-    "@nsid": "VIAFEXP759860203",
-    "#text": "XR|VIAFEXP759860203"
-  }},
-  "length": "11",
-  "mainHeadings":   {
-    "data":     {
-      "text": "Benét, Stephen Vincent, 1898-1943. | America | Bulgarian 9999",
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP759860203"
-      }
-    },
-    "mainHeadingEl":     {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "100",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
-          },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "0",
-            "#text": "(viaf)100260717"
-          },
-                    {
-            "@code": "t",
-            "#text": "America"
-          },
-                    {
-            "@code": "l",
-            "#text": "Bulgarian"
-          },
-                    {
-            "@code": "f",
-            "#text": "9999"
-          }
-        ]
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP759860203"
-      },
-      "id": "XR|VIAFEXP759860203"
-    }
-  },
-  "fixed": {"gender": "u"},
-  "x400s": {"x400":   {
-    "datafield":     {
-      "@ind1": "1",
-      "@ind2": " ",
-      "@tag": "400",
-      "@dtype": "MARC21",
-      "subfield":       [
-                {
-          "@code": "a",
-          "#text": "Benét, Stephen Vincent,"
-        },
-                {
-          "@code": "d",
-          "#text": "1898-1943."
-        },
-                {
-          "@code": "t",
-          "#text": "Amerika"
-        },
-                {
-          "@code": "f",
-          "#text": "9999"
-        }
-      ],
-      "normalized": "benet stephen vincent 1898 1943 amerika 9999"
-    },
-    "sources":     {
-      "s": "XR",
-      "sid": "XR|VIAFEXP759860203"
-    }
-  }},
-  "birthDate": "0",
-  "deathDate": "0",
-  "dateType": "lived",
-  "languageOfEntity": {"data":   {
-    "text": "bul",
-    "sources": {"s": "XR"}
-  }},
-  "titles":   {
-    "author":     {
-      "@id": "VIAF|100260717",
-      "text": "Benét, Stephen Vincent"
-    },
-    "work":     {
-      "@id": "VIAF|307979935",
-      "title": "America"
-    }
-  },
-  "history": {"ht":   {
-    "@recid": "XR|VIAFEXP759860203",
-    "@time": "2015-06-15T20:42:24+00:00"
-  }},
-  "creationtime": "2017-08-13T09:02:37.856828+00:00"
-}
-            }}
-            ,
-            {"record":{
-            "recordSchema":"http://viaf.org/VIAFCluster",
-            "recordPacking":"json",
-            
-            "recordData":{
-  "@xmlns": "http://viaf.org/viaf/terms#",
-  "@xmlns:foaf": "http://xmlns.com/foaf/0.1/",
-  "@xmlns:owl": "http://www.w3.org/2002/07/owl#",
-  "@xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-  "@xmlns:void": "http://rdfs.org/ns/void#",
-  "viafID": "314936441",
-  "Document":   {
-    "@about": "http://viaf.org/viaf/314936441/",
-    "inDataset": {"@resource": "http://viaf.org/viaf/data"},
-    "primaryTopic": {"@resource": "http://viaf.org/viaf/314936441"}
-  },
-  "nameType": "UniformTitleExpression",
-  "sources": {"source":   {
-    "@nsid": "VIAFEXP17829827",
-    "#text": "XR|VIAFEXP17829827"
-  }},
-  "length": "12",
-  "mainHeadings":   {
-    "data":     {
-      "text": "Benét, Stephen Vincent, 1898-1943. | America | German 1944",
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP17829827"
-      }
-    },
-    "mainHeadingEl":     {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "100",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
-          },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "0",
-            "#text": "(viaf)100260717"
-          },
-                    {
-            "@code": "t",
-            "#text": "America"
-          },
-                    {
-            "@code": "l",
-            "#text": "German"
-          },
-                    {
-            "@code": "f",
-            "#text": "1944"
-          }
-        ]
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP17829827"
-      },
-      "id": "XR|VIAFEXP17829827"
-    }
-  },
-  "fixed": {"gender": "u"},
-  "x400s": {"x400":   [
+{
+  "searchRetrieveResponse": {
+    "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+    "xmlns": "http://www.loc.gov/zing/srw/",
+    "records": {
+      "xmlns:ns1": "http://www.loc.gov/zing/srw/",
+      "record": [
         {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "400",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 1 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
           },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "t",
-            "#text": "Amerika : Geschichte der USA"
-          },
-                    {
-            "@code": "f",
-            "#text": "1944"
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "xsi:type": "ns1:stringOrXmlFragment",
+            "ns2:VIAFCluster": {
+              "ns2:languageOfEntity": {
+                "ns2:data": {
+                  "ns2:sources": { "ns2:s": ["BNF", "LC", "SIMACOB", "J9U"] },
+                  "ns2:text": "eng"
+                }
+              },
+              "ns2:viafID": 100260717,
+              "ns2:history": {
+                "ns2:ht": [
+                  {
+                    "time": "2009-11-11T06:00:16+00:00",
+                    "type": "add",
+                    "recid": "LC|n  50007691"
+                  },
+                  {
+                    "time": "2009-11-11T06:00:16+00:00",
+                    "type": "add",
+                    "recid": "PTBNP|124245"
+                  },
+                  {
+                    "time": "2009-11-11T06:00:16+00:00",
+                    "type": "add",
+                    "recid": "DNB|124803946"
+                  },
+                  {
+                    "time": "2009-11-11T06:00:16+00:00",
+                    "type": "add",
+                    "recid": "BNF|12370814"
+                  },
+                  {
+                    "time": "2011-12-15T07:58:57+00:00",
+                    "type": "add",
+                    "recid": "SUDOC|032734816"
+                  },
+                  {
+                    "time": "2012-07-25T04:18:43+00:00",
+                    "type": "add",
+                    "recid": "NKC|xx0150962"
+                  },
+                  {
+                    "time": "2012-09-21T12:24:30+00:00",
+                    "type": "add",
+                    "recid": "NDL|00519944"
+                  },
+                  {
+                    "time": "2012-11-27T04:00:16+00:00",
+                    "type": "delete",
+                    "recid": "BIBSYS|x90150860"
+                  },
+                  {
+                    "time": "2012-12-19T19:11:18+00:00",
+                    "type": "add",
+                    "recid": "NTA|070665478"
+                  },
+                  {
+                    "time": "2013-01-14T22:09:03+00:00",
+                    "type": "add",
+                    "recid": "SELIBR|177274"
+                  },
+                  {
+                    "time": "2013-05-13T19:14:22+00:00",
+                    "type": "delete",
+                    "recid": "NLIlat|000018789"
+                  },
+                  {
+                    "time": "2013-08-19T18:59:48+00:00",
+                    "type": "add",
+                    "recid": "LNB|LNC10-000036793"
+                  },
+                  {
+                    "time": "2013-09-16T16:15:07+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000107867406"
+                  },
+                  {
+                    "time": "2013-12-12T18:02:00+00:00",
+                    "type": "add",
+                    "recid": "NSK|000107922"
+                  },
+                  {
+                    "time": "2014-04-14T18:18:00+00:00",
+                    "type": "add",
+                    "recid": "ICCU|MILV147708"
+                  },
+                  {
+                    "time": "2015-03-11T21:41:54+00:00",
+                    "type": "add",
+                    "recid": "NUKAT|n  98700739"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q1348138"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "delete",
+                    "recid": "WKP|Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "time": "2015-05-12T00:14:00+00:00",
+                    "type": "add",
+                    "recid": "N6I|vtls000005570"
+                  },
+                  {
+                    "time": "2015-05-12T00:14:00+00:00",
+                    "type": "add",
+                    "recid": "DBC|87097969383254"
+                  },
+                  {
+                    "time": "2015-11-17T21:06:54.839779+00:00",
+                    "type": "add",
+                    "recid": "EGAXA|vtls000807500"
+                  },
+                  {
+                    "time": "2016-02-13T18:33:37.480770+00:00",
+                    "type": "delete",
+                    "recid": "DNB|1064304281"
+                  },
+                  {
+                    "time": "2016-02-13T18:33:37.553794+00:00",
+                    "type": "delete",
+                    "recid": "DNB|18642969X"
+                  },
+                  {
+                    "time": "2016-03-21T07:27:33.199909+00:00",
+                    "type": "add",
+                    "recid": "BNCHL|10000000000000000052154"
+                  },
+                  {
+                    "time": "2016-08-01T02:05:47.572178+00:00",
+                    "type": "add",
+                    "recid": "NII|DA03285494"
+                  },
+                  {
+                    "time": "2017-04-01T11:12:44.619598+00:00",
+                    "type": "add",
+                    "recid": "BIBSYS|90150860"
+                  },
+                  {
+                    "time": "2018-12-03T07:12:11.725042+00:00",
+                    "type": "delete",
+                    "recid": "LIH|LNB:P9e;=BU"
+                  },
+                  {
+                    "time": "2018-12-03T09:03:48.961766+00:00",
+                    "type": "add",
+                    "recid": "LIH|LNB:P9_e_;=BU"
+                  },
+                  {
+                    "time": "2018-12-09T17:09:07.026107+00:00",
+                    "type": "add",
+                    "recid": "SIMACOB|34977123"
+                  },
+                  {
+                    "time": "2019-06-09T12:03:36.069541+00:00",
+                    "type": "add",
+                    "recid": "PLWABN|9810675783605606"
+                  },
+                  {
+                    "time": "2019-07-14T12:04:01.138671+00:00",
+                    "type": "delete",
+                    "recid": "NLP|a11008647"
+                  },
+                  {
+                    "time": "2020-02-02T16:00:20.720577+00:00",
+                    "type": "add",
+                    "recid": "J9U|987007258412405171"
+                  },
+                  {
+                    "time": "2020-04-12T08:53:39.654128+00:00",
+                    "type": "delete",
+                    "recid": "NLI|000018789"
+                  },
+                  {
+                    "time": "2020-06-16T21:10:43.976719+00:00",
+                    "type": "delete",
+                    "recid": "RERO|vtls002992101"
+                  },
+                  {
+                    "time": "2020-07-14T12:52:31.142900+00:00",
+                    "type": "delete",
+                    "recid": "BAV|ADV12624073"
+                  },
+                  {
+                    "time": "2020-07-14T12:56:49.461654+00:00",
+                    "type": "add",
+                    "recid": "CAOONL|ncf12143156"
+                  },
+                  {
+                    "time": "2020-10-18T22:55:07.109008+00:00",
+                    "type": "add",
+                    "recid": "RERO|A002992101"
+                  },
+                  {
+                    "time": "2020-10-18T22:55:07.122797+00:00",
+                    "type": "add",
+                    "recid": "NLR|RU NLR AUTH 770129075"
+                  },
+                  {
+                    "time": "2021-04-18T20:00:42.889609+00:00",
+                    "type": "add",
+                    "recid": "BAV|495_335719"
+                  },
+                  {
+                    "time": "2023-01-22T12:51:33.922362+00:00",
+                    "type": "add",
+                    "recid": "W2Z|90150860"
+                  },
+                  {
+                    "time": "2023-08-20T18:22:01.990550+00:00",
+                    "type": "add",
+                    "recid": "NLA|000035017300"
+                  },
+                  {
+                    "time": "2024-08-04T01:37:13.585532+00:00",
+                    "type": "add",
+                    "recid": "KRNLK|KAC199602154"
+                  },
+                  {
+                    "time": "2025-03-17T19:30:37.978559+00:00",
+                    "type": "add",
+                    "recid": "GRATEVE|126106"
+                  },
+                  {
+                    "time": "2025-04-20T01:09:24.158515+00:00",
+                    "type": "delete",
+                    "recid": "BNE|XX981097"
+                  }
+                ]
+              },
+              "ns2:RecFormats": {
+                "ns2:data": [
+                  {
+                    "count": 4,
+                    "ns2:sources": {
+                      "ns2:s": ["BNCHL", "NUKAT"],
+                      "ns2:sid": [
+                        "BNCHL|10000000000000000052154",
+                        "NUKAT|n  98700739"
+                      ]
+                    },
+                    "ns2:text": "aa"
+                  },
+                  {
+                    "count": 386,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "LC",
+                        "BNCHL",
+                        "N6I",
+                        "NSK",
+                        "RERO",
+                        "NDL",
+                        "SIMACOB",
+                        "SELIBR",
+                        "W2Z",
+                        "NTA",
+                        "BNF",
+                        "PTBNP",
+                        "BIBSYS",
+                        "NKC",
+                        "KRNLK",
+                        "DBC",
+                        "CAOONL",
+                        "SUDOC",
+                        "J9U",
+                        "NUKAT",
+                        "NLR",
+                        "DNB",
+                        "EGAXA",
+                        "LNB"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "LC|n  50007691",
+                        "BNCHL|10000000000000000052154",
+                        "N6I|vtls000005570",
+                        "NSK|000107922",
+                        "RERO|A002992101",
+                        "NDL|00519944",
+                        "SIMACOB|34977123",
+                        "SELIBR|177274",
+                        "W2Z|90150860",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "PTBNP|124245",
+                        "BIBSYS|90150860",
+                        "NKC|xx0150962",
+                        "KRNLK|KAC199602154",
+                        "DBC|87097969383254",
+                        "CAOONL|ncf12143156",
+                        "SUDOC|032734816",
+                        "J9U|987007258412405171",
+                        "NUKAT|n  98700739",
+                        "NLR|RU NLR AUTH 770129075",
+                        "DNB|124803946",
+                        "EGAXA|vtls000807500",
+                        "LNB|LNC10-000036793"
+                      ]
+                    },
+                    "ns2:text": "am"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "BNF"],
+                      "ns2:sid": ["SUDOC|032734816", "BNF|12370814"]
+                    },
+                    "ns2:text": "as"
+                  },
+                  {
+                    "count": 7,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SELIBR", "BNF", "RERO"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "SELIBR|177274",
+                        "BNF|12370814",
+                        "RERO|A002992101"
+                      ]
+                    },
+                    "ns2:text": "cm"
+                  },
+                  {
+                    "count": 36,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "dm"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "em"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "BIBSYS",
+                      "ns2:sid": "BIBSYS|90150860"
+                    },
+                    "ns2:text": "ga"
+                  },
+                  {
+                    "count": 20,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "BIBSYS",
+                        "LC",
+                        "SUDOC",
+                        "KRNLK",
+                        "RERO",
+                        "NTA",
+                        "BNF"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "SUDOC|032734816",
+                        "KRNLK|KAC199602154",
+                        "RERO|A002992101",
+                        "NTA|070665478",
+                        "BNF|12370814"
+                      ]
+                    },
+                    "ns2:text": "gm"
+                  },
+                  {
+                    "count": 10,
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "LC"],
+                      "ns2:sid": ["CAOONL|ncf12143156", "LC|n  50007691"]
+                    },
+                    "ns2:text": "im"
+                  },
+                  {
+                    "count": 6,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "PLWABN"],
+                      "ns2:sid": ["LC|n  50007691", "PLWABN|9810675783605606"]
+                    },
+                    "ns2:text": "jm"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": "mm"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "om"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "pc"
+                  }
+                ]
+              },
+              "ns2:titles": {
+                "ns2:work": [
+                  {
+                    "ns2:title": "Abraham Lincoln",
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "BIBSYS"],
+                      "ns2:sid": ["SUDOC|032734816", "BIBSYS|90150860"]
+                    }
+                  },
+                  {
+                    "ns2:title": "All that money can buy",
+                    "ns2:sources": {
+                      "ns2:s": ["KRNLK", "NTA", "BNF"],
+                      "ns2:sid": [
+                        "KRNLK|KAC199602154",
+                        "NTA|070665478",
+                        "BNF|12370814"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "America",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "XR",
+                        "PLWABN",
+                        "WKP",
+                        "BIBSYS",
+                        "LC",
+                        "NKC",
+                        "RERO",
+                        "SUDOC",
+                        "NUKAT",
+                        "SIMACOB",
+                        "DNB",
+                        "BNF",
+                        "EGAXA",
+                        "SELIBR",
+                        "NTA",
+                        "NII"
+                      ],
+                      "ns2:sid": [
+                        "XR|VIAFWORK1001517648",
+                        "PLWABN|9810675783605606",
+                        "WKP|Q1348138",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "RERO|A002992101",
+                        "SUDOC|032734816",
+                        "NUKAT|n  98700739",
+                        "SIMACOB|34977123",
+                        "DNB|124803946",
+                        "BNF|12370814",
+                        "EGAXA|vtls000807500",
+                        "SELIBR|177274",
+                        "NTA|070665478",
+                        "NII|DA03285494"
+                      ]
+                    },
+                    "id": "VIAF|6052161332386452420007"
+                  },
+                  {
+                    "ns2:title": "Amerika Geschichte der USA",
+                    "ns2:sources": {
+                      "ns2:s": ["RERO", "NUKAT", "DNB"],
+                      "ns2:sid": [
+                        "RERO|A002992101",
+                        "NUKAT|n  98700739",
+                        "DNB|124803946"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Amerika : Minshu shugi no ayumi",
+                    "ns2:sources": { "ns2:s": "NDL", "ns2:sid": "NDL|00519944" }
+                  },
+                  {
+                    "ns2:title": "Ameryka",
+                    "ns2:sources": {
+                      "ns2:s": ["NUKAT", "PLWABN"],
+                      "ns2:sid": [
+                        "NUKAT|n  98700739",
+                        "PLWABN|9810675783605606"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "\u0100mr\u012bk\u0101",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    }
+                  },
+                  {
+                    "ns2:title": "Ballads and poems, 1915-1930",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "BIBSYS"],
+                      "ns2:sid": ["LC|n  50007691", "BIBSYS|90150860"]
+                    }
+                  },
+                  {
+                    "ns2:title": "The Barly fields, a collection of five novels",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SUDOC"],
+                      "ns2:sid": ["LC|n  50007691", "SUDOC|032734816"]
+                    }
+                  },
+                  {
+                    "ns2:title": "The beginning of wisdom",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NTA", "BIBSYS", "SUDOC"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NTA|070665478",
+                        "BIBSYS|90150860",
+                        "SUDOC|032734816"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Bischofs Bettler Erz\u00e4hlung",
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "RERO", "DNB", "NTA"],
+                      "ns2:sid": [
+                        "CAOONL|ncf12143156",
+                        "RERO|A002992101",
+                        "DNB|124803946",
+                        "NTA|070665478"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "bishop's Beggar",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "DNB"],
+                      "ns2:sid": ["LC|n  50007691", "DNB|124803946"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Burning city, new poems",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SELIBR", "BIBSYS", "NII"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "SELIBR|177274",
+                        "BIBSYS|90150860",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "By the waters of Babylon",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NII", "SUDOC", "BNF", "WKP"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NII|DA03285494",
+                        "SUDOC|032734816",
+                        "BNF|12370814",
+                        "WKP|Q1348138"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Cotton Mather;",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    }
+                  },
+                  {
+                    "ns2:title": "Devil and Daniel Webster",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "J9U",
+                        "PLWABN",
+                        "LC",
+                        "BIBSYS",
+                        "NUKAT",
+                        "SIMACOB",
+                        "CAOONL",
+                        "NTA",
+                        "NLA",
+                        "KRNLK",
+                        "RERO",
+                        "BNF",
+                        "DNB",
+                        "XR",
+                        "SELIBR",
+                        "SUDOC",
+                        "NII",
+                        "WKP"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SIMACOB|34977123",
+                        "CAOONL|ncf11593398",
+                        "NTA|070665478",
+                        "KRNLK|KAC199602154",
+                        "RERO|A002992101",
+                        "BNF|12370814",
+                        "DNB|124803946",
+                        "SELIBR|177274",
+                        "SUDOC|032734816",
+                        "NII|DA03285494",
+                        "WKP|Q1348138"
+                      ]
+                    },
+                    "id": "VIAF|184038065"
+                  },
+                  {
+                    "ns2:title": "D\u02b9i\ufe20a\ufe21vol i Dani\u0117l\u02b9 Vebster : i drugie rasskazy.",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    }
+                  },
+                  {
+                    "ns2:title": "The drug-shop, 1917.",
+                    "ns2:sources": {
+                      "ns2:s": ["N6I", "LC", "CAOONL", "J9U"],
+                      "ns2:sid": [
+                        "N6I|vtls000005570",
+                        "LC|n  50007691",
+                        "CAOONL|ncf12143156",
+                        "J9U|987007258412405171"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "The drug-shop, or, Endymion in Edmonstoun",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    }
+                  },
+                  {
+                    "ns2:title": "For My People",
+                    "ns2:sources": {
+                      "ns2:s": ["SELIBR", "SUDOC", "BIBSYS"],
+                      "ns2:sid": [
+                        "SELIBR|177274",
+                        "SUDOC|032734816",
+                        "BIBSYS|90150860"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Gendai amerika tanpenshu.",
+                    "ns2:sources": { "ns2:s": "NDL", "ns2:sid": "NDL|00519944" }
+                  },
+                  {
+                    "ns2:title": "Die gute Wahl 6 stories",
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    }
+                  },
+                  {
+                    "ns2:title": "Headless horseman",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NLA"],
+                      "ns2:sid": ["LC|n  50007691", "NLA|000036549017"]
+                    },
+                    "id": "VIAF|181822947"
+                  },
+                  {
+                    "ns2:title": "His most famous stories and poems",
+                    "ns2:sources": {
+                      "ns2:s": ["BNCHL", "SUDOC"],
+                      "ns2:sid": [
+                        "BNCHL|10000000000000000052154",
+                        "SUDOC|032734816"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Historia sucinta de los Estados Unidos",
+                    "ns2:sources": {
+                      "ns2:s": ["BNCHL", "SUDOC", "NII"],
+                      "ns2:sid": [
+                        "BNCHL|10000000000000000052154",
+                        "SUDOC|032734816",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "James Shore's daughter",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NKC", "SELIBR", "SUDOC", "NII"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "SELIBR|177274",
+                        "SUDOC|032734816",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Jean Huguenot",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NKC"],
+                      "ns2:sid": ["LC|n  50007691", "NKC|xx0150962"]
+                    }
+                  },
+                  {
+                    "ns2:title": "John Brown's body",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "XR",
+                        "BIBSYS",
+                        "LC",
+                        "NKC",
+                        "N6I",
+                        "RERO",
+                        "CAOONL",
+                        "SUDOC",
+                        "WKP",
+                        "NUKAT",
+                        "SIMACOB",
+                        "SELIBR",
+                        "BNF",
+                        "LNB",
+                        "NTA",
+                        "NII"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "XR|VIAFWORK10730655",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "N6I|vtls000005570",
+                        "RERO|A002992101",
+                        "CAOONL|ncf12143156",
+                        "SUDOC|032734816",
+                        "WKP|Q1348138",
+                        "NUKAT|n  98700739",
+                        "SIMACOB|34977123",
+                        "SELIBR|177274",
+                        "BNF|12370814",
+                        "LNB|LNC10-000036793",
+                        "NTA|070665478",
+                        "NII|DA03285494"
+                      ]
+                    },
+                    "id": "VIAF|309266498"
+                  },
+                  {
+                    "ns2:title": "Johnny Pye & the fool-killer",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SELIBR", "NII", "DNB"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "SELIBR|177274",
+                        "LC|no 98042928",
+                        "NII|DA03285494",
+                        "DNB|124803946"
+                      ]
+                    },
+                    "id": "VIAF|182479486"
+                  },
+                  {
+                    "ns2:title": "Een kind is ons geboren",
+                    "ns2:sources": {
+                      "ns2:s": "NTA",
+                      "ns2:sid": "NTA|070665478"
+                    }
+                  },
+                  {
+                    "ns2:title": "King of the cats",
+                    "ns2:sources": {
+                      "ns2:s": "XR",
+                      "ns2:sid": "XR|VIAFWORKNUKATn 2018064391"
+                    },
+                    "id": "VIAF|1839165326594616290007"
+                  },
+                  {
+                    "ns2:title": "The last circle",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "LC",
+                        "SUDOC",
+                        "NSK",
+                        "SELIBR",
+                        "DNB",
+                        "NTA",
+                        "NII"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "LC|n  50007691",
+                        "SUDOC|032734816",
+                        "NSK|000107922",
+                        "SELIBR|177274",
+                        "DNB|124803946",
+                        "NTA|070665478",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Letania para las dictaduras (Fragmentos)",
+                    "ns2:sources": {
+                      "ns2:s": "BNCHL",
+                      "ns2:sid": "BNCHL|10000000000000000052154"
+                    }
+                  },
+                  {
+                    "ns2:title": "The litter rose leaves . Tabloid news . Gehenna . Feathers . The American county fair . Fine furniture",
+                    "ns2:sources": {
+                      "ns2:s": "NII",
+                      "ns2:sid": "NII|DA03285494"
+                    }
+                  },
+                  {
+                    "ns2:title": "Musical collection",
+                    "ns2:sources": {
+                      "ns2:s": "DBC",
+                      "ns2:sid": "DBC|87097969383254"
+                    }
+                  },
+                  {
+                    "ns2:title": "n50007691",
+                    "ns2:sources": { "ns2:s": "NDL", "ns2:sid": "NDL|00519944" }
+                  },
+                  {
+                    "ns2:title": "Nad rzekami Babilonu",
+                    "ns2:sources": {
+                      "ns2:s": ["NUKAT", "PLWABN"],
+                      "ns2:sid": [
+                        "NUKAT|n  98700739",
+                        "PLWABN|9810675783605606"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Nightmare at noon",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    }
+                  },
+                  {
+                    "ns2:title": "O'Halloran's luck and other short stories",
+                    "ns2:sources": {
+                      "ns2:s": ["ICCU", "NUKAT", "NTA", "NII"],
+                      "ns2:sid": [
+                        "ICCU|MILV147708",
+                        "NUKAT|n  98700739",
+                        "NTA|070665478",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Paul Revere. Selections",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|no 98029245"
+                    },
+                    "id": "VIAF|178436001"
+                  },
+                  {
+                    "ns2:title": "Poems. Selections",
+                    "ns2:sources": {
+                      "ns2:s": ["NLA", "LC"],
+                      "ns2:sid": ["LC|n  50007691", "LC|no 98041779"]
+                    },
+                    "id": "VIAF|182887548"
+                  },
+                  {
+                    "ns2:title": "Power and the land :",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "BIBSYS"],
+                      "ns2:sid": ["LC|n  50007691", "BIBSYS|90150860"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Prayer for the United Nations",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "WKP"],
+                      "ns2:sid": ["LC|n  50007691", "WKP|Q1348138"]
+                    }
+                  },
+                  {
+                    "ns2:title": "roi des chats",
+                    "ns2:sources": {
+                      "ns2:s": ["RERO", "LC", "SUDOC", "BNF"],
+                      "ns2:sid": [
+                        "RERO|A002992101",
+                        "LC|n  50007691",
+                        "SUDOC|032734816",
+                        "BNF|12370814"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Selected letters.",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NTA"],
+                      "ns2:sid": ["LC|n  50007691", "NTA|070665478"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Selected poetry and prose;",
+                    "ns2:sources": {
+                      "ns2:s": ["BIBSYS", "LC", "NUKAT", "SUDOC", "NII"],
+                      "ns2:sid": [
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SUDOC|032734816",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Selected stories.",
+                    "ns2:sources": {
+                      "ns2:s": ["N6I", "SELIBR"],
+                      "ns2:sid": ["N6I|vtls000005570", "SELIBR|177274"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Selected works of Stephen Vincent Benet.",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PTBNP",
+                        "PLWABN",
+                        "BIBSYS",
+                        "LC",
+                        "NKC",
+                        "NUKAT",
+                        "ICCU",
+                        "NTA",
+                        "SIMACOB",
+                        "DNB",
+                        "BNF",
+                        "RERO",
+                        "SELIBR",
+                        "SUDOC",
+                        "NII"
+                      ],
+                      "ns2:sid": [
+                        "PTBNP|124245",
+                        "PLWABN|9810675783605606",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "NUKAT|n  98700739",
+                        "ICCU|MILV147708",
+                        "NTA|070665478",
+                        "SIMACOB|34977123",
+                        "DNB|124803946",
+                        "BNF|12370814",
+                        "RERO|A002992101",
+                        "SELIBR|177274",
+                        "SUDOC|032734816",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "sept femmes de Barberousse",
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "BNF"],
+                      "ns2:sid": ["SUDOC|032734816", "BNF|12370814"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Seven brides for seven brothers",
+                    "ns2:sources": {
+                      "ns2:s": ["DBC", "PLWABN", "NTA", "BNF", "SUDOC"],
+                      "ns2:sid": [
+                        "DBC|87097969383254",
+                        "PLWABN|9810675783605606",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "SUDOC|032734816"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Shortcut to happiness",
+                    "ns2:sources": {
+                      "ns2:s": ["KRNLK", "PLWABN"],
+                      "ns2:sid": [
+                        "KRNLK|KAC199602154",
+                        "PLWABN|9810675783605606"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Skarb Vasko Gomet\ufe20s\ufe21ka, 1946:",
+                    "ns2:sources": {
+                      "ns2:s": ["N6I", "LC", "CAOONL"],
+                      "ns2:sid": [
+                        "N6I|vtls000005570",
+                        "LC|n  50007691",
+                        "CAOONL|ncf12143156"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Spanish bayonet.",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NUKAT", "SELIBR"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SELIBR|177274"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Stories & poems from the twilight",
+                    "ns2:sources": {
+                      "ns2:s": ["W2Z", "BIBSYS"],
+                      "ns2:sid": ["W2Z|90150860", "BIBSYS|90150860"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Story by Angela Poe",
+                    "ns2:sources": {
+                      "ns2:s": "XR",
+                      "ns2:sid": "XR|VIAFWORKNUKATn 2018104827"
+                    },
+                    "id": "VIAF|380165326421916290007"
+                  },
+                  {
+                    "ns2:title": "Tales before midnight",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "PLWABN", "SUDOC", "NII"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "PLWABN|9810675783605606",
+                        "SUDOC|032734816",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Thirteen o'clock",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n 2014031768"
+                    },
+                    "id": "VIAF|308755803"
+                  },
+                  {
+                    "ns2:title": "Thirteen o'clock. Sobbin' women",
+                    "ns2:sources": {
+                      "ns2:s": ["NLA", "J9U", "BIBSYS", "LC", "NTA", "NII"],
+                      "ns2:sid": [
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "LC|n 2014031766",
+                        "NTA|070665478",
+                        "NII|DA03285494"
+                      ]
+                    },
+                    "id": "VIAF|178573712"
+                  },
+                  {
+                    "ns2:title": "Tooth for Paul Revere",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "XR"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "XR|VIAFWORKNUKATn 2010116416"
+                      ]
+                    },
+                    "id": "VIAF|204165326400416290002"
+                  },
+                  {
+                    "ns2:title": "Tous les biens de la terre",
+                    "ns2:sources": {
+                      "ns2:s": ["RERO", "BNF"],
+                      "ns2:sid": ["RERO|A002992101", "BNF|12370814"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Twenty five Short Stories",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "BIBSYS",
+                        "LC",
+                        "NKC",
+                        "RERO",
+                        "SELIBR",
+                        "BNF",
+                        "DNB",
+                        "SUDOC",
+                        "NII"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "RERO|A002992101",
+                        "SELIBR|177274",
+                        "BNF|12370814",
+                        "DNB|124803946",
+                        "SUDOC|032734816",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "La valle delle sabine : Traduzione dall'Inglese di Margherita Santi Farina",
+                    "ns2:sources": {
+                      "ns2:s": "ICCU",
+                      "ns2:sid": "ICCU|MILV147708"
+                    }
+                  },
+                  {
+                    "ns2:title": "Warm river",
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    }
+                  },
+                  {
+                    "ns2:title": "We stand united and other radio scripts / by Stephen Vincent Ben\u00e9t ; with a foreword by Norman Rosten ; decorated by Ernest Stock",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "ICCU", "SELIBR", "BIBSYS", "NII"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "ICCU|MILV147708",
+                        "SELIBR|177274",
+                        "BIBSYS|90150860",
+                        "NII|DA03285494"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Western star",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PTBNP",
+                        "PLWABN",
+                        "WKP",
+                        "BIBSYS",
+                        "LC",
+                        "NKC",
+                        "NUKAT",
+                        "NLA",
+                        "N6I",
+                        "SIMACOB",
+                        "SELIBR",
+                        "RERO",
+                        "LNB",
+                        "SUDOC",
+                        "BNF"
+                      ],
+                      "ns2:sid": [
+                        "PTBNP|124245",
+                        "PLWABN|9810675783605606",
+                        "WKP|Q1348138",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "NUKAT|n  98700739",
+                        "NLA|000035159285",
+                        "N6I|vtls000005570",
+                        "SIMACOB|34977123",
+                        "SELIBR|177274",
+                        "RERO|A002992101",
+                        "LNB|LNC10-000036793",
+                        "SUDOC|032734816",
+                        "BNF|12370814"
+                      ]
+                    },
+                    "id": "VIAF|176955585"
+                  },
+                  {
+                    "ns2:title": "Works. Selections. 1942",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "NTA",
+                        "LC",
+                        "NUKAT",
+                        "SUDOC",
+                        "NLA",
+                        "SELIBR",
+                        "RERO",
+                        "NKC"
+                      ],
+                      "ns2:sid": [
+                        "NTA|070665478",
+                        "LC|n  50007691",
+                        "LC|no 98113501",
+                        "NUKAT|n  98700739",
+                        "SUDOC|032734816",
+                        "SELIBR|177274",
+                        "RERO|A002992101",
+                        "NKC|xx0150962"
+                      ]
+                    },
+                    "id": "VIAF|174812559"
+                  },
+                  {
+                    "ns2:title": "Works. Selections. 1960",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|no2017146649"
+                    },
+                    "id": "VIAF|7007151112589137180006"
+                  },
+                  {
+                    "ns2:title": "The Yale book of student verse, 1910-1919",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    }
+                  },
+                  {
+                    "ns2:title": "Young adventure; a book of poems",
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "BIBSYS",
+                        "LC",
+                        "SUDOC",
+                        "SELIBR",
+                        "LNB",
+                        "NTA"
+                      ],
+                      "ns2:sid": [
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "SUDOC|032734816",
+                        "SELIBR|177274",
+                        "LNB|LNC10-000036793",
+                        "NTA|070665478"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "Young people's pride; a novel",
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NTA"],
+                      "ns2:sid": ["LC|n  50007691", "NTA|070665478"]
+                    }
+                  },
+                  {
+                    "ns2:title": "Zero hour a summons to the free",
+                    "ns2:sources": {
+                      "ns2:s": ["DNB", "SELIBR", "LC", "NUKAT", "SUDOC"],
+                      "ns2:sid": [
+                        "DNB|124803946",
+                        "SELIBR|177274",
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SUDOC|032734816"
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:title": "\u0422\u0435\u043b\u043e \u0414\u0436\u043e\u043d\u0430 \u0411\u0440\u0430\u0443\u043d\u0430",
+                    "ns2:sources": {
+                      "ns2:s": ["NLR", "NII"],
+                      "ns2:sid": ["NLR|RU NLR AUTH 770129075", "NII|DA03285494"]
+                    }
+                  },
+                  {
+                    "ns2:title": "\u05e9\u05d8\u05df \u05d5\u05e0\u05d7\u05e9 \u05d4\u05e2\u05e7\u05dc\u05ea\u05d5\u05df",
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    }
+                  },
+                  {
+                    "ns2:title": "\u0627\u0645\u0631\u064a\u0643\u0627",
+                    "ns2:sources": {
+                      "ns2:s": "EGAXA",
+                      "ns2:sid": "EGAXA|vtls000807500"
+                    }
+                  },
+                  {
+                    "ns2:title": "\ub2ec\ucf64\ud55c \uc545\ub9c8\uc758 \uc720\ud639",
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    }
+                  },
+                  {
+                    "ns2:title": "\uc804\uc6d0",
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    }
+                  },
+                  {
+                    "ns2:title": "\uc815\ub2e4\uc6b4 \u6c5f",
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    }
+                  },
+                  {
+                    "ns2:title": "\u30a2\u30e1\u30ea\u30ab : \u6c11\u4e3b\u4e3b\u7fa9\u306e\u3042\u3086\u307f",
+                    "ns2:sources": {
+                      "ns2:s": ["NDL", "NII"],
+                      "ns2:sid": ["NDL|00519944", "NII|DA03285494"]
+                    }
+                  },
+                  {
+                    "ns2:title": "\u73fe\u4ee3\u30a2\u30e1\u30ea\u30ab\u77ed\u7bc7\u96c6.",
+                    "ns2:sources": { "ns2:s": "NDL", "ns2:sid": "NDL|00519944" }
+                  },
+                  {
+                    "ns2:title": "\u9ed1\u591c\u715e\u661f",
+                    "ns2:sources": { "ns2:s": "WKP", "ns2:sid": "WKP|Q1348138" }
+                  }
+                ]
+              },
+              "ns2:fixed": { "ns2:gender": "b" },
+              "ns2:length": 7171,
+              "ns2:countries": {
+                "ns2:data": [
+                  {
+                    "scaled": 8,
+                    "count": 304,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "NLR",
+                        "PTBNP",
+                        "PLWABN",
+                        "BIBSYS",
+                        "KRNLK",
+                        "LC",
+                        "NKC",
+                        "NUKAT",
+                        "SIMACOB",
+                        "RERO",
+                        "SUDOC",
+                        "N6I",
+                        "NSK",
+                        "DNB",
+                        "CAOONL",
+                        "SELIBR",
+                        "LNB",
+                        "NTA",
+                        "BNF"
+                      ],
+                      "ns2:sid": [
+                        "NLR|RU NLR AUTH 770129075",
+                        "PTBNP|124245",
+                        "PLWABN|9810675783605606",
+                        "BIBSYS|90150860",
+                        "KRNLK|KAC199602154",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "NUKAT|n  98700739",
+                        "SIMACOB|34977123",
+                        "RERO|A002992101",
+                        "SUDOC|032734816",
+                        "N6I|vtls000005570",
+                        "NSK|000107922",
+                        "DNB|124803946",
+                        "CAOONL|ncf12143156",
+                        "SELIBR|177274",
+                        "LNB|LNC10-000036793",
+                        "NTA|070665478",
+                        "BNF|12370814"
+                      ]
+                    },
+                    "ns2:text": "US"
+                  },
+                  {
+                    "scaled": 5,
+                    "count": 35,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "LC",
+                        "NUKAT",
+                        "SIMACOB",
+                        "DNB",
+                        "CAOONL",
+                        "RERO",
+                        "NTA"
+                      ],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SIMACOB|34977123",
+                        "DNB|124803946",
+                        "CAOONL|ncf12143156",
+                        "RERO|A002992101",
+                        "NTA|070665478"
+                      ]
+                    },
+                    "ns2:text": "DE"
+                  },
+                  {
+                    "scaled": 5,
+                    "count": 28,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "RERO", "SUDOC", "BNF"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "RERO|A002992101",
+                        "SUDOC|032734816",
+                        "BNF|12370814"
+                      ]
+                    },
+                    "ns2:text": "FR"
+                  },
+                  {
+                    "scaled": 4,
+                    "count": 14,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "LC",
+                        "NKC",
+                        "SUDOC",
+                        "N6I",
+                        "SELIBR",
+                        "RERO",
+                        "NTA"
+                      ],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "SUDOC|032734816",
+                        "N6I|vtls000005570",
+                        "SELIBR|177274",
+                        "RERO|A002992101",
+                        "NTA|070665478"
+                      ]
+                    },
+                    "ns2:text": "GB"
+                  },
+                  {
+                    "scaled": 3,
+                    "count": 10,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NUKAT", "PLWABN"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "PLWABN|9810675783605606"
+                      ]
+                    },
+                    "ns2:text": "PL"
+                  },
+                  {
+                    "scaled": 2,
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": "KI"
+                  },
+                  {
+                    "scaled": 2,
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": "NDL",
+                      "ns2:sid": "NDL|00519944"
+                    },
+                    "ns2:text": "JP"
+                  },
+                  {
+                    "scaled": 2,
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "BNCHL", "SUDOC"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "BNCHL|10000000000000000052154",
+                        "SUDOC|032734816"
+                      ]
+                    },
+                    "ns2:text": "AR"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["W2Z", "BIBSYS"],
+                      "ns2:sid": ["W2Z|90150860", "BIBSYS|90150860"]
+                    },
+                    "ns2:text": "NO"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "NTA",
+                      "ns2:sid": "NTA|070665478"
+                    },
+                    "ns2:text": "NL"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:text": "IL"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "DBC",
+                      "ns2:sid": "DBC|87097969383254"
+                    },
+                    "ns2:text": "DK"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "PLWABN"],
+                      "ns2:sid": [
+                        "CAOONL|ncf12143156",
+                        "PLWABN|9810675783605606"
+                      ]
+                    },
+                    "ns2:text": "CA"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "NLR",
+                      "ns2:sid": "NLR|RU NLR AUTH 770129075"
+                    },
+                    "ns2:text": "RU"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "PE"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "IT"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "IN"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "N6I",
+                      "ns2:sid": "N6I|vtls000005570"
+                    },
+                    "ns2:text": "IE"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "ID"
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "EGAXA",
+                      "ns2:sid": "EGAXA|vtls000807500"
+                    },
+                    "ns2:text": "EG"
+                  }
+                ]
+              },
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns2:dateType": "lived",
+              "xmlns:ns2": "http://viaf.org/viaf/terms#",
+              "ns2:coauthors": {
+                "ns2:data": [
+                  {
+                    "count": 17,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SELIBR", "BIBSYS"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "SELIBR|177274",
+                        "BIBSYS|90150860"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Moore, Douglas, 1893-1969."
+                  },
+                  {
+                    "count": 13,
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "NTA", "BNF", "ISNI"],
+                      "ns2:sid": [
+                        "SUDOC|032734816",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Powell, Jane 1929-...."
+                  },
+                  {
+                    "count": 13,
+                    "ns2:sources": {
+                      "ns2:s": ["DBC", "SUDOC", "BNF", "ISNI"],
+                      "ns2:sid": [
+                        "DBC|87097969383254",
+                        "SUDOC|032734816",
+                        "BNF|12370814",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Kingsley, Dorothy 1909-1997"
+                  },
+                  {
+                    "count": 13,
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "NTA", "BNF", "ISNI"],
+                      "ns2:sid": [
+                        "SUDOC|032734816",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Keel, Howard 1919-2004"
+                  },
+                  {
+                    "count": 13,
+                    "ns2:sources": {
+                      "ns2:s": ["DBC", "SUDOC", "BNF", "ISNI"],
+                      "ns2:sid": [
+                        "DBC|87097969383254",
+                        "SUDOC|032734816",
+                        "BNF|12370814",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Hackett, Albert 1900-1995"
+                  },
+                  {
+                    "count": 13,
+                    "ns2:sources": {
+                      "ns2:s": ["DBC", "SUDOC", "BNF", "ISNI"],
+                      "ns2:sid": [
+                        "DBC|87097969383254",
+                        "SUDOC|032734816",
+                        "BNF|12370814",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Goodrich, Frances 1890-1984"
+                  },
+                  {
+                    "count": 13,
+                    "ns2:sources": {
+                      "ns2:s": ["DBC", "NTA", "BNF", "SUDOC"],
+                      "ns2:sid": [
+                        "DBC|87097969383254",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "SUDOC|032734816"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Donen, Stanley 1924-...."
+                  },
+                  {
+                    "count": 9,
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "BNF"],
+                      "ns2:sid": ["SUDOC|032734816", "BNF|12370814"]
+                    },
+                    "tag": 950,
+                    "ns2:text": "De Paul, Gene 1919-1988"
+                  },
+                  {
+                    "count": 8,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SELIBR", "RERO"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "SELIBR|177274",
+                        "RERO|A002992101"
+                      ]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Ben\u00e9t, Rosemary, 1900-1962"
+                  },
+                  {
+                    "count": 7,
+                    "ns2:sources": {
+                      "ns2:s": ["SUDOC", "BNF"],
+                      "ns2:sid": ["SUDOC|032734816", "BNF|12370814"]
+                    },
+                    "tag": 950,
+                    "ns2:text": "Richards, Jeff 1924-1989"
+                  },
+                  {
+                    "count": 6,
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Henry, O. 1862-1910"
+                  },
+                  {
+                    "count": 5,
+                    "ns2:sources": {
+                      "ns2:s": "NUKAT",
+                      "ns2:sid": "NUKAT|n  98700739"
+                    },
+                    "tag": 951,
+                    "ns2:text": "Rinehart and Company."
+                  },
+                  {
+                    "count": 5,
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Knesebeck, Paridam \u0098von dem\u009c"
+                  },
+                  {
+                    "count": 4,
+                    "ns2:sources": {
+                      "ns2:s": "SELIBR",
+                      "ns2:sid": "SELIBR|177274"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Carmer, Carl."
+                  },
+                  {
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Davenport, Basil"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "tag": 950,
+                    "ns2:text": "\u05d8\u05e8\u05d1\u05e8, \u05d2'\u05d9\u05d9\u05de\u05e1."
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "BIBSYS",
+                      "ns2:sid": "BIBSYS|90150860"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Van Dongen, Helen"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "SIMACOB",
+                      "ns2:sid": "SIMACOB|34977123"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Untermeyer, Louis,  1885-1977."
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "NDL",
+                      "ns2:sid": "NDL|00519944"
+                    },
+                    "tag": 950,
+                    "ns2:text": "\u5742\u897f, \u5fd7\u4fdd, 1896-1976."
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "PLWABN",
+                      "ns2:sid": "PLWABN|9810675783605606"
+                    },
+                    "tag": 951,
+                    "ns2:text": "Zak\u0142ady Fonograficzne \"Muza\""
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "W2Z",
+                      "ns2:sid": "W2Z|90150860"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Wynn, Michael 1973-"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "PTBNP",
+                      "ns2:sid": "PTBNP|124245"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Wells, H. G., 1866-1946"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "RERO",
+                      "ns2:sid": "RERO|A002992101"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Totheroh, Dan"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "CAOONL",
+                      "ns2:sid": "CAOONL|ncf12143156"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Laughton, Charles, 1899-1962"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "N6I",
+                      "ns2:sid": "N6I|vtls000005570"
+                    },
+                    "tag": 950,
+                    "ns2:text": "Curry, John Steuart, 1897-1946."
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "EGAXA",
+                      "ns2:sid": "EGAXA|vtls000807500"
+                    },
+                    "tag": 950,
+                    "ns2:text": "\u0639\u0628\u062f \u0627\u0644\u0645\u062c\u064a\u062f\u060c \u0639\u0628\u062f \u0627\u0644\u0639\u0632\u064a\u0632."
+                  }
+                ]
+              },
+              "ns2:deathDate": "1943-03-13",
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns2:x500s": {
+                "ns2:x500": [
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose" },
+                        { "code": "d", "content": "1886-1950" },
+                        { "code": "e", "content": "Beziehung familiaer" }
+                      ],
+                      "ns2:normalized": "benet william rose 1886 1950",
+                      "dtype": "MARC21",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "viafLink": 235043729,
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": " ",
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Bethlehem, Pa."
+                      },
+                      "ns2:normalized": "bethlehem pa",
+                      "dtype": "MARC21",
+                      "tag": 551
+                    }
+                  },
+                  {
+                    "viafLink": 266415900,
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": " ",
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "New York, NY"
+                      },
+                      "ns2:normalized": "new york ny",
+                      "dtype": "MARC21",
+                      "tag": 551
+                    }
+                  }
+                ]
+              },
+              "ns2:covers": {
+                "ns2:data": {
+                  "count": 2,
+                  "ns2:sources": {
+                    "ns2:s": ["LC", "BIBSYS"],
+                    "ns2:sid": ["LC|n  50007691", "BIBSYS|90150860"]
+                  },
+                  "ns2:text": "0805002979"
+                }
+              },
+              "ns2:fieldOfActivity": {
+                "ns2:data": {
+                  "ns2:sources": { "ns2:s": "KRNLK" },
+                  "ns2:text": "\uc601\ubbf8 \ubb38\ud559\u82f1\u7f8e\u349a\u5b66"
+                }
+              },
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns2:publishers": {
+                "ns2:data": [
+                  {
+                    "count": 75,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PTBNP",
+                        "PLWABN",
+                        "BIBSYS",
+                        "LC",
+                        "NKC",
+                        "NUKAT",
+                        "N6I",
+                        "DNB",
+                        "ISNI",
+                        "RERO",
+                        "LNB",
+                        "SUDOC"
+                      ],
+                      "ns2:sid": [
+                        "PTBNP|124245",
+                        "PLWABN|9810675783605606",
+                        "BIBSYS|90150860",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "NUKAT|n  98700739",
+                        "N6I|vtls000005570",
+                        "DNB|124803946",
+                        "ISNI|0000000107867406",
+                        "RERO|A002992101",
+                        "LNB|LNC10-000036793",
+                        "SUDOC|032734816"
+                      ]
+                    },
+                    "ns2:text": "Farrar & Rinehart, inc."
+                  },
+                  {
+                    "count": 31,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "SIMACOB",
+                        "SELIBR",
+                        "ISNI",
+                        "LC",
+                        "NUKAT",
+                        "NTA",
+                        "BNF",
+                        "SUDOC"
+                      ],
+                      "ns2:sid": [
+                        "SIMACOB|34977123",
+                        "SELIBR|177274",
+                        "ISNI|0000000107867406",
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "SUDOC|032734816"
+                      ]
+                    },
+                    "ns2:text": "Rinehart & Company"
+                  },
+                  {
+                    "count": 23,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "SELIBR",
+                        "BIBSYS",
+                        "ISNI",
+                        "LC",
+                        "NUKAT",
+                        "SUDOC",
+                        "BNF",
+                        "NTA"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "SELIBR|177274",
+                        "BIBSYS|90150860",
+                        "ISNI|0000000107867406",
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SUDOC|032734816",
+                        "BNF|12370814",
+                        "NTA|070665478"
+                      ]
+                    },
+                    "ns2:text": "Yale University Press"
+                  },
+                  {
+                    "count": 19,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "BIBSYS",
+                        "ISNI",
+                        "LC",
+                        "NKC",
+                        "NUKAT",
+                        "LNB",
+                        "NTA"
+                      ],
+                      "ns2:sid": [
+                        "BIBSYS|90150860",
+                        "ISNI|0000000107867406",
+                        "LC|n  50007691",
+                        "NKC|xx0150962",
+                        "NUKAT|n  98700739",
+                        "LNB|LNC10-000036793",
+                        "NTA|070665478"
+                      ]
+                    },
+                    "ns2:text": "Doubleday, Doran & company, inc."
+                  },
+                  {
+                    "count": 18,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NUKAT", "SUDOC", "BIBSYS", "ISNI"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NUKAT|n  98700739",
+                        "SUDOC|032734816",
+                        "BIBSYS|90150860",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "ns2:text": "Holt, Rinehart and Winston"
+                  },
+                  {
+                    "count": 14,
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "DNB",
+                        "BIBSYS",
+                        "ISNI",
+                        "PLWABN",
+                        "NUKAT",
+                        "SUDOC",
+                        "BNF",
+                        "NTA"
+                      ],
+                      "ns2:sid": [
+                        "DNB|124803946",
+                        "BIBSYS|90150860",
+                        "ISNI|0000000107867406",
+                        "PLWABN|9810675783605606",
+                        "NUKAT|n  98700739",
+                        "SUDOC|032734816",
+                        "BNF|12370814",
+                        "NTA|070665478"
+                      ]
+                    },
+                    "ns2:text": "Overseas Editions"
+                  },
+                  {
+                    "count": 10,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NTA", "BIBSYS"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NTA|070665478",
+                        "BIBSYS|90150860"
+                      ]
+                    },
+                    "ns2:text": "H. Holt and company"
+                  },
+                  {
+                    "count": 9,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "Library of Congress Magnetic Recording Laboratory"
+                  },
+                  {
+                    "count": 9,
+                    "ns2:sources": {
+                      "ns2:s": ["DNB", "ISNI"],
+                      "ns2:sid": ["DNB|124803946", "ISNI|0000000107867406"]
+                    },
+                    "ns2:text": "Dt. Nationalbibliothek"
+                  },
+                  {
+                    "count": 8,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "NTA", "SUDOC"],
+                      "ns2:sid": [
+                        "LC|n  50007691",
+                        "NTA|070665478",
+                        "SUDOC|032734816"
+                      ]
+                    },
+                    "ns2:text": "Editions for the Armed Services"
+                  },
+                  {
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:text": "\u4e59\u9149\u6587\u5316\u793e"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "NDL",
+                      "ns2:sid": "NDL|00519944"
+                    },
+                    "ns2:text": "\u7814\u7a76\u793e\u51fa\u7248"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "EGAXA",
+                      "ns2:sid": "EGAXA|vtls000807500"
+                    },
+                    "ns2:text": "\u0645\u0643\u062a\u0628 \u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0644\u0644\u0627\u0633\u062a\u0639\u0644\u0627\u0645\u0627\u062a\u060c"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:text": "\u05e0\u05d4\u05e8 \u05e1\u05e4\u05e8\u05d9\u05dd"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "NLR",
+                      "ns2:sid": "NLR|RU NLR AUTH 770129075"
+                    },
+                    "ns2:text": "\u0427\u0430\u0439\u043a\u0430"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "DBC",
+                      "ns2:sid": "DBC|87097969383254"
+                    },
+                    "ns2:text": "Warner Bros. Entertainment Danmark"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "CAOONL",
+                      "ns2:sid": "CAOONL|ncf12143156"
+                    },
+                    "ns2:text": "Voss"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "BNCHL",
+                      "ns2:sid": "BNCHL|10000000000000000052154"
+                    },
+                    "ns2:text": "Pocket Books"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "W2Z",
+                      "ns2:sid": "W2Z|90150860"
+                    },
+                    "ns2:text": "Historyradio.org"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "NSK",
+                      "ns2:sid": "NSK|000107922"
+                    },
+                    "ns2:text": "Farrar, Straus and Company"
+                  }
+                ]
+              },
+              "ns2:mainHeadings": {
+                "ns2:mainHeadingEl": [
+                  {
+                    "ns2:id": "ISNI|0000000107867406",
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet, Stephen Vincent" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "GRATEVE|126106",
+                    "ns2:sources": {
+                      "ns2:s": "GRATEVE",
+                      "ns2:sid": "GRATEVE|126106"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet, Stephen Vincent," },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 0, "content": "urn:nbn:gr:nlg:01-A072723" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "PTBNP|124245",
+                    "ns2:sources": {
+                      "ns2:s": "PTBNP",
+                      "ns2:sid": "PTBNP|124245"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet," },
+                        { "code": "b", "content": "Stephen Vincent," },
+                        { "code": "f", "content": "1898-1943" }
+                      ],
+                      "dtype": "UNIMARC",
+                      "tag": 200
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "ICCU|MILV147708",
+                    "ns2:sources": {
+                      "ns2:s": "ICCU",
+                      "ns2:sid": "ICCU|MILV147708"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t" },
+                        { "code": "b", "content": ", Stephen Vincent" }
+                      ],
+                      "dtype": "UNIMARC",
+                      "tag": 200
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "title" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "BNF|12370814",
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:datafield": {
+                      "ind2": "|",
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": 7, "content": "ba0yba0y" },
+                        { "code": 8, "content": "fre" },
+                        { "code": 9, "content": 0 },
+                        { "code": "a", "content": "Ben\u00e9t" },
+                        { "code": "b", "content": "Stephen Vincent" },
+                        { "code": "f", "content": "1898-1943" }
+                      ],
+                      "dtype": "UNIMARC",
+                      "tag": 200
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "standard number" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "LIH|LNB:P9_e_;=BU",
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t" },
+                        { "code": "b", "content": "Stephen Vincent" },
+                        { "code": "f", "content": "1898-1943" }
+                      ],
+                      "dtype": "UNIMARC",
+                      "tag": 200
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "DNB|124803946",
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "SUDOC|032734816",
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "standard number" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NLA|000035017300",
+                    "ns2:sources": {
+                      "ns2:s": "NLA",
+                      "ns2:sid": "NLA|000035017300"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NTA|070665478",
+                    "ns2:sources": {
+                      "ns2:s": "NTA",
+                      "ns2:sid": "NTA|070665478"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "LC|n  50007691",
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "title" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "CAOONL|ncf12143156",
+                    "ns2:sources": {
+                      "ns2:s": "CAOONL",
+                      "ns2:sid": "CAOONL|ncf12143156"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "BAV|495_335719",
+                    "ns2:sources": {
+                      "ns2:s": "BAV",
+                      "ns2:sid": "BAV|495_335719"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00a9\u266dt, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "SELIBR|177274",
+                    "ns2:sources": {
+                      "ns2:s": "SELIBR",
+                      "ns2:sid": "SELIBR|177274"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NII|DA03285494",
+                    "ns2:sources": {
+                      "ns2:s": "NII",
+                      "ns2:sid": "NII|DA03285494"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "title" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "RERO|A002992101",
+                    "ns2:sources": {
+                      "ns2:s": "RERO",
+                      "ns2:sid": "RERO|A002992101"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "joint author" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "standard number" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "standard number" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NSK|000107922",
+                    "ns2:sources": {
+                      "ns2:s": "NSK",
+                      "ns2:sid": "NSK|000107922"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "DBC|87097969383254",
+                    "ns2:sources": {
+                      "ns2:s": "DBC",
+                      "ns2:sid": "DBC|87097969383254"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "partial date and publisher" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "exact name" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "PLWABN|9810675783605606",
+                    "ns2:sources": {
+                      "ns2:s": "PLWABN",
+                      "ns2:sid": "PLWABN|9810675783605606"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "(1898-1943)" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BAV|495_335719"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NLR|RU NLR AUTH 770129075"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NUKAT|n  98700739",
+                    "ns2:sources": {
+                      "ns2:s": "NUKAT",
+                      "ns2:sid": "NUKAT|n  98700739"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "(1898-1943)." }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "BIBSYS|90150860",
+                    "ns2:sources": {
+                      "ns2:s": "BIBSYS",
+                      "ns2:sid": "BIBSYS|90150860"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BAV|495_335719"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NLR|RU NLR AUTH 770129075"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "W2Z|90150860",
+                    "ns2:sources": {
+                      "ns2:s": "W2Z",
+                      "ns2:sid": "W2Z|90150860"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BAV|495_335719"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "ICCU|MILV147708"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NLR|RU NLR AUTH 770129075"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "KRNLK|KAC199602154",
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "SIMACOB|34977123",
+                    "ns2:sources": {
+                      "ns2:s": "SIMACOB",
+                      "ns2:sid": "SIMACOB|34977123"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "J9U|987007258412405171",
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 9, "content": "lat" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NKC|xx0150962",
+                    "ns2:sources": {
+                      "ns2:s": "NKC",
+                      "ns2:sid": "NKC|xx0150962"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 7, "content": "xx0150962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NDL|00519944",
+                    "ns2:sources": {
+                      "ns2:s": "NDL",
+                      "ns2:sid": "NDL|00519944"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "N6I|vtls000005570",
+                    "ns2:sources": {
+                      "ns2:s": "N6I",
+                      "ns2:sid": "N6I|vtls000005570"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "LNB|LNC10-000036793",
+                    "ns2:sources": {
+                      "ns2:s": "LNB",
+                      "ns2:sid": "LNB|LNC10-000036793"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "BNCHL|10000000000000000052154",
+                    "ns2:sources": {
+                      "ns2:s": "BNCHL",
+                      "ns2:sid": "BNCHL|10000000000000000052154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "B\u00e9net, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "WKP|Q1348138",
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Stephen Vincent Ben\u00e9t"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NSK|000107922"
+                        },
+                        {
+                          "ns2:match": { "type": "exact title" },
+                          "content": "RERO|A002992101"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "SELIBR|177274"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NII|DA03285494"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLR|RU NLR AUTH 770129075"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "NLR|RU NLR AUTH 770129075",
+                    "ns2:sources": {
+                      "ns2:s": "NLR",
+                      "ns2:sid": "NLR|RU NLR AUTH 770129075"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "\u0411\u0435\u043d\u0435" },
+                        { "code": "b", "content": "\u0421. \u0412." },
+                        { "code": "f", "content": "1898-1943" },
+                        {
+                          "code": "g",
+                          "content": "\u0421\u0442\u0438\u0432\u0435\u043d \u0412\u0435\u043d\u0441\u0435\u043d\u0442"
+                        }
+                      ],
+                      "dtype": "UNIMARC",
+                      "tag": 200
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "J9U|987007258412405171",
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05d9\u05d1\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8,"
+                        },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 9, "content": "heb" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "EGAXA|vtls000807500",
+                    "ns2:sources": {
+                      "ns2:s": "EGAXA",
+                      "ns2:sid": "EGAXA|vtls000807500"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0628\u0646\u064a\u0647\u060c \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a\u060c"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "J9U|987007258412405171"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns2:id": "J9U|987007258412405171",
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0628\u0646\u064a\u0647\u060c \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a\u060c"
+                        },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 9, "content": "ara" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns2:links": {
+                      "ns2:link": [
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "PLWABN|9810675783605606"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "LC|n  50007691"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000052154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LIH|LNB:P9_e_;=BU"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "N6I|vtls000005570"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SIMACOB|34977123"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "KRNLK|KAC199602154"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "ISNI|0000000107867406"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "W2Z|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NTA|070665478"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "BNF|12370814"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "PTBNP|124245"
+                        },
+                        {
+                          "ns2:match": { "type": "suggested" },
+                          "content": "WKP|Q1348138"
+                        },
+                        {
+                          "ns2:match": { "type": "viafid" },
+                          "content": "BIBSYS|90150860"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NKC|xx0150962"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NLA|000035017300"
+                        },
+                        {
+                          "ns2:match": { "type": "forced single date" },
+                          "content": "DBC|87097969383254"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "CAOONL|ncf12143156"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "SUDOC|032734816"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "GRATEVE|126106"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "NUKAT|n  98700739"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "DNB|124803946"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "NDL|00519944"
+                        },
+                        {
+                          "ns2:match": { "type": "lccn" },
+                          "content": "EGAXA|vtls000807500"
+                        },
+                        {
+                          "ns2:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000036793"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "ns2:data": [
+                  {
+                    "ns2:sources": {
+                      "ns2:s": [
+                        "PLWABN",
+                        "LC",
+                        "BNCHL",
+                        "LIH",
+                        "N6I",
+                        "SIMACOB",
+                        "KRNLK",
+                        "ISNI",
+                        "W2Z",
+                        "NTA",
+                        "BNF",
+                        "PTBNP",
+                        "BIBSYS",
+                        "NKC",
+                        "NLA",
+                        "CAOONL",
+                        "SUDOC",
+                        "J9U",
+                        "GRATEVE",
+                        "NUKAT",
+                        "DNB",
+                        "NDL",
+                        "LNB"
+                      ],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "LC|n  50007691",
+                        "BNCHL|10000000000000000052154",
+                        "LIH|LNB:P9_e_;=BU",
+                        "N6I|vtls000005570",
+                        "SIMACOB|34977123",
+                        "KRNLK|KAC199602154",
+                        "ISNI|0000000107867406",
+                        "W2Z|90150860",
+                        "NTA|070665478",
+                        "BNF|12370814",
+                        "PTBNP|124245",
+                        "BIBSYS|90150860",
+                        "NKC|xx0150962",
+                        "NLA|000035017300",
+                        "CAOONL|ncf12143156",
+                        "SUDOC|032734816",
+                        "J9U|987007258412405171",
+                        "GRATEVE|126106",
+                        "NUKAT|n  98700739",
+                        "DNB|124803946",
+                        "NDL|00519944",
+                        "LNB|LNC10-000036793"
+                      ]
+                    },
+                    "ns2:text": "B\u00e9net, Stephen Vincent, 1898-1943"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["NSK", "DBC", "ICCU", "SELIBR", "RERO", "NII"],
+                      "ns2:sid": [
+                        "NSK|000107922",
+                        "DBC|87097969383254",
+                        "ICCU|MILV147708",
+                        "SELIBR|177274",
+                        "RERO|A002992101",
+                        "NII|DA03285494"
+                      ]
+                    },
+                    "ns2:text": "Ben\u00e9t, Stephen Vincent"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:text": "Stephen Vincent Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["EGAXA", "J9U"],
+                      "ns2:sid": [
+                        "EGAXA|vtls000807500",
+                        "J9U|987007258412405171"
+                      ]
+                    },
+                    "ns2:text": "\u0628\u0646\u064a\u0647\u060c \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a\u060c 1898-1943"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:text": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05d9\u05d1\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8, 1898-1943"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NLR",
+                      "ns2:sid": "NLR|RU NLR AUTH 770129075"
+                    },
+                    "ns2:text": "\u0411\u0435\u043d\u0435, \u0421. \u0412. 1898-1943 \u0421\u0442\u0438\u0432\u0435\u043d \u0412\u0435\u043d\u0441\u0435\u043d\u0442"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "BAV",
+                      "ns2:sid": "BAV|495_335719"
+                    },
+                    "ns2:text": "Ben\u00a9\u266dt, Stephen Vincent"
+                  }
+                ]
+              },
+              "ns2:Document": {
+                "ns2:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/100260717"
+                },
+                "about": "http://viaf.org/viaf/100260717/",
+                "ns2:inDataset": { "resource": "http://viaf.org/viaf/data" }
+              },
+              "ns2:birthDate": "1898-07-22",
+              "ns2:sources": {
+                "ns2:source": [
+                  {
+                    "nsid": "http://catalogue.bnf.fr/ark:/12148/cb123708149",
+                    "content": "BNF|12370814"
+                  },
+                  { "nsid": 870979.69383254, "content": "DBC|87097969383254" },
+                  {
+                    "nsid": "http://d-nb.info/gnd/124803946",
+                    "content": "DNB|124803946"
+                  },
+                  {
+                    "nsid": "IT\\ICCU\\MILV\\147708",
+                    "content": "ICCU|MILV147708"
+                  },
+                  {
+                    "nsid": "0000000107867406",
+                    "content": "ISNI|0000000107867406"
+                  },
+                  { "nsid": "n50007691", "content": "LC|n  50007691" },
+                  {
+                    "nsid": "LNC10-000036793",
+                    "content": "LNB|LNC10-000036793"
+                  },
+                  { "nsid": "vtls000005570", "content": "N6I|vtls000005570" },
+                  { "nsid": "00519944", "content": "NDL|00519944" },
+                  { "nsid": "xx0150962", "content": "NKC|xx0150962" },
+                  { "nsid": "000107922", "content": "NSK|000107922" },
+                  { "nsid": "070665478", "content": "NTA|070665478" },
+                  { "nsid": "vtls000127962", "content": "NUKAT|n  98700739" },
+                  { "nsid": 124245, "content": "PTBNP|124245" },
+                  { "nsid": "ljx00n340qdn2lp", "content": "SELIBR|177274" },
+                  { "nsid": "032734816", "content": "SUDOC|032734816" },
+                  { "nsid": "Q1348138", "content": "WKP|Q1348138" },
+                  { "nsid": "vtls000807500", "content": "EGAXA|vtls000807500" },
+                  {
+                    "nsid": "BNC10000000000000000052154",
+                    "content": "BNCHL|10000000000000000052154"
+                  },
+                  { "nsid": "DA03285494", "content": "NII|DA03285494" },
+                  { "nsid": 90150860, "content": "BIBSYS|90150860" },
+                  { "nsid": "LNB:P9e;=BU", "content": "LIH|LNB:P9_e_;=BU" },
+                  { "nsid": 34977123, "content": "SIMACOB|34977123" },
+                  {
+                    "nsid": 9810675783605606,
+                    "content": "PLWABN|9810675783605606"
+                  },
+                  {
+                    "nsid": 987007258412405171,
+                    "content": "J9U|987007258412405171"
+                  },
+                  { "nsid": "ncf12143156", "content": "CAOONL|ncf12143156" },
+                  { "nsid": "A002992101", "content": "RERO|A002992101" },
+                  {
+                    "nsid": "RU\\NLR\\AUTH\\770129075",
+                    "content": "NLR|RU NLR AUTH 770129075"
+                  },
+                  {
+                    "nsid": "495/335719",
+                    "sparse": true,
+                    "content": "BAV|495_335719"
+                  },
+                  { "nsid": 90150860, "content": "W2Z|90150860" },
+                  { "nsid": "000035017300", "content": "NLA|000035017300" },
+                  { "nsid": "KAC199602154", "content": "KRNLK|KAC199602154" },
+                  { "nsid": 126106, "content": "GRATEVE|126106" }
+                ]
+              },
+              "ns2:occupation": {
+                "ns2:data": [
+                  {
+                    "ns2:sources": { "ns2:s": ["LC", "J9U"] },
+                    "ns2:text": "poets"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": ["LC", "J9U"] },
+                    "ns2:text": "novelists"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": ["LC", "J9U"] },
+                    "ns2:text": "authors"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": "KRNLK" },
+                    "ns2:text": "\uc791\uac00 \uc0ac\ub78c \u4f5c\u50a2"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": "KRNLK" },
+                    "ns2:text": "\uc2dc\uc778 \uc2dc \u8a69\u4eba"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": "KRNLK" },
+                    "ns2:text": "\uc18c\uc124\uac00\u5c0f\u8aaa\u50a2"
+                  }
+                ]
+              },
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns2:nationalityOfEntity": {
+                "ns2:data": [
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["BNF", "DNB", "ISNI", "PTBNP", "WKP"]
+                    },
+                    "ns2:text": "US"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": ["DBC", "BIBSYS", "W2Z"] },
+                    "ns2:text": "us"
+                  },
+                  {
+                    "ns2:sources": { "ns2:s": "KRNLK" },
+                    "ns2:text": "\ubbf8\uad6d(\uad6d\uba85)[\u7f8e\u570b]"
+                  },
+                  { "ns2:sources": { "ns2:s": "SIMACOB" }, "ns2:text": "usa" }
+                ]
+              },
+              "ns2:nameType": "Personal",
+              "ns2:creationtime": "2025-04-20T08:50:06.045043+00:00",
+              "ns2:dates": {
+                "min": 191,
+                "max": 201,
+                "ns2:date": [
+                  { "scaled": 3.91, "count": 15, "content": 191 },
+                  { "scaled": 5.43, "count": 43, "content": 192 },
+                  { "scaled": 6, "count": 64, "content": 193 },
+                  { "scaled": 7.45, "count": 175, "content": 194 },
+                  { "scaled": 5.46, "count": 44, "content": 195 },
+                  { "scaled": 5.32, "count": 40, "content": 196 },
+                  { "scaled": 4.7, "count": 26, "content": 197 },
+                  { "scaled": 4.39, "count": 21, "content": 198 },
+                  { "scaled": 3.7, "count": 13, "content": 199 },
+                  { "scaled": 4.81, "count": 28, "content": 200 },
+                  { "scaled": 4.32, "count": 20, "content": 201 }
+                ]
+              },
+              "ns2:RelatorCodes": {
+                "ns2:data": [
+                  {
+                    "count": 19,
+                    "ns2:sources": {
+                      "ns2:s": ["NLR", "BNF"],
+                      "ns2:sid": ["NLR|RU NLR AUTH 770129075", "BNF|12370814"]
+                    },
+                    "ns2:text": "070"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": "080"
+                  },
+                  {
+                    "count": 7,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": 100
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": 340
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": 690
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "BNF",
+                      "ns2:sid": "BNF|12370814"
+                    },
+                    "ns2:text": 730
+                  },
+                  {
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": "BIBSYS",
+                      "ns2:sid": "BIBSYS|90150860"
+                    },
+                    "ns2:text": "aus"
+                  },
+                  {
+                    "count": 11,
+                    "ns2:sources": {
+                      "ns2:s": ["SIMACOB", "KRNLK", "DNB", "W2Z", "BIBSYS"],
+                      "ns2:sid": [
+                        "SIMACOB|34977123",
+                        "KRNLK|KAC199602154",
+                        "DNB|124803946",
+                        "W2Z|90150860",
+                        "BIBSYS|90150860"
+                      ]
+                    },
+                    "ns2:text": "aut"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "PLWABN",
+                      "ns2:sid": "PLWABN|9810675783605606"
+                    },
+                    "ns2:text": "aut oryg"
+                  },
+                  {
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "auteur"
+                  },
+                  {
+                    "count": 5,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "auteur adapte precedent"
+                  },
+                  {
+                    "count": 4,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "author"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "PLWABN",
+                      "ns2:sid": "PLWABN|9810675783605606"
+                    },
+                    "ns2:text": "autor oryg"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "BIBSYS",
+                      "ns2:sid": "BIBSYS|90150860"
+                    },
+                    "ns2:text": "cmm"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "collaborateur"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:text": "ctb"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "directeur de la publication"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "ed"
+                  },
+                  {
+                    "count": 7,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SELIBR"],
+                      "ns2:sid": ["LC|n  50007691", "SELIBR|177274"]
+                    },
+                    "ns2:text": "lbt"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "librettist"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "lyricist"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:text": "mitwirkender"
+                  },
+                  {
+                    "count": 4,
+                    "ns2:sources": {
+                      "ns2:s": "SELIBR",
+                      "ns2:sid": "SELIBR|177274"
+                    },
+                    "ns2:text": "oth"
+                  },
+                  {
+                    "count": 4,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "preface"
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": "SUDOC",
+                      "ns2:sid": "SUDOC|032734816"
+                    },
+                    "ns2:text": "scenario"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "PLWABN",
+                      "ns2:sid": "PLWABN|9810675783605606"
+                    },
+                    "ns2:text": "sl"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:text": "verfasser"
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": "writing"
+                  }
+                ]
+              },
+              "ns2:x400s": {
+                "ns2:x400": [
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "BNCHL",
+                      "ns2:sid": "BNCHL|10000000000000000052154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Banayh, Stivin Vinsint," },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "banayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Banayh, Stivin Vinsint" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "banayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "LC", "J9U"],
+                      "ns2:sid": [
+                        "CAOONL|ncf12143156",
+                        "LC|n  50007691",
+                        "J9U|987007258412405171"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Banayh, St\u012bvin Vinsint,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "banayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NII",
+                      "ns2:sid": "NII|DA03285494"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Banayh, St\u012bvin Vinsint"
+                      },
+                      "ns2:normalized": "banayh stivin vinsint",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "N6I",
+                      "ns2:sid": "N6I|vtls000005570"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Banayh, St\u012bvin Vinsint,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "banayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Banayh, St\u012bvin Vinsint"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "banayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Banayh" },
+                        { "code": "b", "content": "Stivin Vinsint" }
+                      ],
+                      "ns2:normalized": "banayh stivin vinsint",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NTA",
+                      "ns2:sid": "NTA|070665478"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Bene, Stiven Vinsent," },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stiven vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Bene, Stiven Vinsent" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stiven vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["N6I", "LC", "CAOONL", "J9U"],
+                      "ns2:sid": [
+                        "N6I|vtls000005570",
+                        "LC|n  50007691",
+                        "CAOONL|ncf12143156",
+                        "J9U|987007258412405171"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet, Stepan Vinsent," },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stepan vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet, Stepan Vinsent" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stepan vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NSK",
+                      "ns2:sid": "NSK|000107922"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Benet, Stephen Vincent"
+                      },
+                      "ns2:normalized": "benet stephen vincent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["KRNLK", "DNB", "ISNI"],
+                      "ns2:sid": [
+                        "KRNLK|KAC199602154",
+                        "DNB|124803946",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet, Stephen Vincent" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stephen vincent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Benet" },
+                        { "code": "b", "content": "Stepan Vinsent" }
+                      ],
+                      "ns2:normalized": "benet stepan vinsent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Bene" },
+                        { "code": "b", "content": "Stifen Vinsent" }
+                      ],
+                      "ns2:normalized": "bene stifen vinsent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Stephen V." },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stephen v 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "DNB",
+                      "ns2:sid": "DNB|124803946"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vinzent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stephen vinzent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "LC", "J9U"],
+                      "ns2:sid": [
+                        "CAOONL|ncf12143156",
+                        "LC|n  50007691",
+                        "J9U|987007258412405171"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u0117, Stifen Vinsent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stifen vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u0117" },
+                        { "code": "b", "content": "Stivenas Vinsentas" }
+                      ],
+                      "ns2:normalized": "bene stivenas vinsentas",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Bent" },
+                        { "code": "b", "content": "Stephen Vincent" }
+                      ],
+                      "ns2:normalized": "bent stephen vincent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9, Stifen Vinsent"
+                      },
+                      "ns2:normalized": "bene stifen vinsent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "BNCHL",
+                      "ns2:sid": "BNCHL|10000000000000000052154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9, Stifen Vinsent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stifen vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u00e9, Stifen Vinsent" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stifen vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["PLWABN", "ISNI"],
+                      "ns2:sid": [
+                        "PLWABN|9810675783605606",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, S. V."
+                      },
+                      "ns2:normalized": "benet s v",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "SIMACOB",
+                      "ns2:sid": "SIMACOB|34977123"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, S.V."
+                      },
+                      "ns2:normalized": "benet s v",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Stephen V." },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stephen v 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vinzent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "benet stephen vinzent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "SIMACOB",
+                      "ns2:sid": "SIMACOB|34977123"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Steven Vincent"
+                      },
+                      "ns2:normalized": "benet steven vincent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NII",
+                      "ns2:sid": "NII|DA03285494"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Ben\u0117, Stifen Vinsent"
+                      },
+                      "ns2:normalized": "bene stifen vinsent",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "N6I",
+                      "ns2:sid": "N6I|vtls000005570"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u0117, Stifen Vinsent,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stifen vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Ben\u0117, Stifen Vinsent" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "bene stifen vinsent 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "BNCHL",
+                      "ns2:sid": "BNCHL|10000000000000000052154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Binayh, Stivin Vinsint," },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "binayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        { "code": "a", "content": "Binayh, Stivin Vinsint" },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "binayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "LC", "J9U"],
+                      "ns2:sid": [
+                        "CAOONL|ncf12143156",
+                        "LC|n  50007691",
+                        "J9U|987007258412405171"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Binayh, St\u012bvin Vinsint,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "binayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "N6I",
+                      "ns2:sid": "N6I|vtls000005570"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Binayh, St\u012bvin Vinsint,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "binayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Binayh, St\u012bvin Vinsint"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "binayh stivin vinsint 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Stephen Ben\u00e9t"
+                      },
+                      "ns2:normalized": "stephen benet",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Stephen Vincent Ben\u00e9t"
+                      },
+                      "ns2:normalized": "stephen vincent benet",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "American poet, short story writer, novelist (1898\u20131943)"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet american poet short story writer novelist 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "Amerikaans dichter (1898\u20131943)"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikaans dichter 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "Amerikaans scenarioschrijver (1898-1943)"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikaans scenarioschrijver 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "Amerikal\u0131 yazar (1898 \u2013 1943)"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikali yazar 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "US-amerikanischer Schriftsteller"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet us amerikanischer schriftsteller",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        { "code": "c", "content": "USA kirjanik" }
+                      ],
+                      "ns2:normalized": "stephen vincent benet usa kirjanik",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "amerikansk poet och manusf\u00f6rfattare"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikansk poet och manusforfattare",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "amerikansk poet og manusforfattar"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikansk poet og manusforfattar",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "amerikansk poet og manusforfatter"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikansk poet og manusforfatter",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "amerikansk poet og manuskriptforfatter"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet amerikansk poet og manuskriptforfatter",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "poeta e scrittore statunitense"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet poeta e scrittore statunitense",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u00e9crivain am\u00e9ricain"
+                        }
+                      ],
+                      "ns2:normalized": "stephen vincent benet ecrivain americain",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "Steven Vincent Benet"
+                      },
+                      "ns2:normalized": "steven vincent benet",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NTA",
+                      "ns2:sid": "NTA|070665478"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0411\u0435\u043d\u0435, \u0421\u0442\u0438\u0432\u0435\u043d \u0412\u0438\u043d\u0441\u0435\u043d\u0442,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\u0431\u0435\u043d\u0435 \u0441\u0442\u0438\u0432\u0435\u043d \u0432\u0438\u043d\u0441\u0435\u043d\u0442 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0411\u0435\u043d\u0435, \u0421\u0442\u0438\u0432\u0435\u043d \u0412\u0438\u043d\u0441\u0435\u043d\u0442"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\u0431\u0435\u043d\u0435 \u0441\u0442\u0438\u0432\u0435\u043d \u0432\u0438\u043d\u0441\u0435\u043d\u0442 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "LIH",
+                      "ns2:sid": "LIH|LNB:P9_e_;=BU"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "\u0411\u0435\u043d\u0435" },
+                        {
+                          "code": "b",
+                          "content": "\u0421\u0442\u0438\u0432\u0435\u043d \u0412\u0438\u043d\u0441\u0435\u043d\u0442"
+                        }
+                      ],
+                      "ns2:normalized": "\u0431\u0435\u043d\u0435 \u0441\u0442\u0438\u0432\u0435\u043d \u0432\u0438\u043d\u0441\u0435\u043d\u0442",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NLR",
+                      "ns2:sid": "NLR|RU NLR AUTH 770129075"
+                    },
+                    "ns2:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "ns2:subfield": [
+                        { "code": "a", "content": "\u0411\u0435\u043d\u044d" },
+                        { "code": "b", "content": "\u0421. \u0412." },
+                        { "code": "f", "content": "1898-1943" },
+                        { "code": 5, "content": "z" }
+                      ],
+                      "ns2:normalized": "\u0431\u0435\u043d\u044d \u0441 \u0432 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u0421\u0442\u0438\u0432\u0435\u043d \u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u0411\u0435\u043d\u0435"
+                      },
+                      "ns2:normalized": "\u0441\u0442\u0438\u0432\u0435\u043d \u0432\u0438\u043d\u0441\u0435\u043d\u0442 \u0431\u0435\u043d\u0435",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u0421\u0442\u044b\u0432\u0435\u043d \u0412\u0456\u043d\u0441\u0435\u043d\u0442 \u0411\u0435\u043d\u044d"
+                      },
+                      "ns2:normalized": "\u0441\u0442\u044b\u0432\u0435\u043d \u0432\u0456\u043d\u0441\u0435\u043d\u0442 \u0431\u0435\u043d\u044d",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u0421\u0442\u0456\u0432\u0435\u043d \u0412\u0456\u043d\u0441\u0435\u043d\u0442 \u0411\u0435\u043d\u0435"
+                      },
+                      "ns2:normalized": "\u0441\u0442\u0456\u0432\u0435\u043d \u0432\u0456\u043d\u0441\u0435\u043d\u0442 \u0431\u0435\u043d\u0435",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u05d1\u05e0\u05d8, \u05e1\u05d8\u05d9\u05d1\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8"
+                      },
+                      "ns2:normalized": "\u05d1\u05e0\u05d8 \u05e1\u05d8\u05d9\u05d1\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8 \u05d1\u05e0\u05d8"
+                      },
+                      "ns2:normalized": "\u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8 \u05d1\u05e0\u05d8",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["WKP", "ISNI"],
+                      "ns2:sid": ["WKP|Q1348138", "ISNI|0000000107867406"]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0627\u0633\u062a\u06cc\u0641\u0646 \u0648\u06cc\u0646\u0633\u0646\u062a \u0628\u0646\u062a"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u0641\u06cc\u0644\u0645\u0646\u0627\u0645\u0647\u200c\u0646\u0648\u06cc\u0633 \u0648 \u0634\u0627\u0639\u0631 \u0622\u0645\u0631\u06cc\u06a9\u0627\u06cc\u06cc"
+                        }
+                      ],
+                      "ns2:normalized": "\u0627\u0633\u062a\u06cc\u0641\u0646 \u0648\u06cc\u0646\u0633\u0646\u062a \u0628\u0646\u062a \u0641\u06cc\u0644\u0645\u0646\u0627\u0645\u0647\u0646\u0648\u06cc\u0633 \u0648 \u0634\u0627\u0639\u0631 \u0627\u0645\u0631\u06cc\u06a9\u0627\u06cc\u06cc",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u0627\u0633\u062a\u06cc\u0648\u0646 \u0648\u06cc\u0646\u0633\u0646\u062a \u0628\u0646\u062a"
+                      },
+                      "ns2:normalized": "\u0627\u0633\u062a\u06cc\u0648\u0646 \u0648\u06cc\u0646\u0633\u0646\u062a \u0628\u0646\u062a",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0628\u064a\u0646\u064a\u062a\u060c \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a\u060c"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\u0628\u064a\u0646\u064a\u062a \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "EGAXA",
+                      "ns2:sid": "EGAXA|vtls000807500"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0628\u064a\u0646\u064a\u062a\u060c \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a\u060c"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\u0628\u064a\u0646\u064a\u062a \u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": ["EGAXA", "ISNI"],
+                      "ns2:sid": [
+                        "EGAXA|vtls000807500",
+                        "ISNI|0000000107867406"
+                      ]
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a \u0628\u0646\u064a\u0647\u060c"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\u0633\u062a\u064a\u0641\u0646 \u0641\u0646\u0633\u0646\u062a \u0628\u0646\u064a\u0647 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u0633\u062a\u064a\u0641\u064a\u0646 \u06a4\u064a\u0646\u0633\u064a\u0646\u062a \u0628\u064a\u0646\u064a\u062a"
+                      },
+                      "ns2:normalized": "\u0633\u062a\u064a\u0641\u064a\u0646 \u06a4\u064a\u0646\u0633\u064a\u0646\u062a \u0628\u064a\u0646\u064a\u062a",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u09b8\u09cd\u099f\u09bf\u09ab\u09c7\u09a8 \u09ad\u09bf\u09a8\u09b8\u09c7\u09a8\u09cd\u099f \u09ac\u09c7\u09a8\u09c7"
+                      },
+                      "ns2:normalized": "\u09b8\u099f\u09ab\u09a8 \u09ad\u09a8\u09b8\u09a8\u099f \u09ac\u09a8",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u0d38\u0d4d\u0d31\u0d4d\u0d31\u0d40\u0d2b\u0d7b \u0d35\u0d3f\u0d7b\u0d38\u0d7b\u0d31\u0d4d \u0d2c\u0d46\u0d28\u0d46\u0d31\u0d4d\u0d31\u0d4d"
+                      },
+                      "ns2:normalized": "\u0d38\u0d31\u0d31\u0d2b\u0d7b \u0d35\u0d7b\u0d38\u0d7b\u0d31 \u0d2c\u0d28\u0d31\u0d31",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u30b9\u30c6\u30a3\u30fc\u30d6\u30f3\u30fb\u30f4\u30a3\u30f3\u30bb\u30f3\u30c8\u30fb\u30d9\u30cd\u30fc"
+                      },
+                      "ns2:normalized": "\u30b9\u30c6\u30a3\u30d5\u30f3 \u30a6\u30a3\u30f3\u30bb\u30f3\u30c8 \u30d8\u30cd",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "ISNI",
+                      "ns2:sid": "ISNI|0000000107867406"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u30d9\u30cd\u30fc"
+                      },
+                      "ns2:normalized": "\u30d8\u30cd",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "NDL",
+                      "ns2:sid": "NDL|00519944"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u30d9\u30cd\u30fc"
+                      },
+                      "ns2:normalized": "\u30d8\u30cd",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u53f2\u8482\u82ac\u00b7\u6587\u68ee\u00b7\u8c9d\u5c3c\u7279"
+                      },
+                      "ns2:normalized": "\u53f2\u8482\u82ac \u349a\u68ee \u8c9d\u5c3c\u7279",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns2:subfield": {
+                        "code": "a",
+                        "content": "\u53f2\u8482\u82ac\u00b7\u6587\u68ee\u7279\u00b7\u672c\u7eb3\u7279"
+                      },
+                      "ns2:normalized": "\u53f2\u8482\u82ac \u349a\u68ee\u7279 \u5932\u7d0d\u7279",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub124, \uc2a4\ud2f0\ube10 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub124 \uc2a4\ud2f0\ube10 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub124, \uc2a4\ud2f0\ube10"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub124 \uc2a4\ud2f0\ube10 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub124\ud2b8, \uc2a4\ud130\ud508 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub124\ud2b8 \uc2a4\ud130\ud508 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub124\ud2b8, \uc2a4\ud14c\ud310 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub124\ud2b8 \uc2a4\ud14c\ud310 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub124\ud2b8, \uc2a4\ud14c\ud508 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub124\ud2b8 \uc2a4\ud14c\ud508 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub12c, \uc2a4\ud14c\uc774\ud508 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub12c \uc2a4\ud14c\uc774\ud508 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub137, \uc2a4\ud14c\ud508 \ube48\uc13c"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub137 \uc2a4\ud14c\ud508 \ube48\uc13c 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub137, \uc2a4\ud14c\ud508 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub137 \uc2a4\ud14c\ud508 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub137, \uc2a4\ud2f0\ube10 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub137 \uc2a4\ud2f0\ube10 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ubca0\ub13d, \uc2a4\ud14c\ud508 \ube48\uc13c"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ubca0\ub13d \uc2a4\ud14c\ud508 \ube48\uc13c 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns2:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\ube44\ub124\uc774, \uc2a4\ud2f0\ube10 \ube48\uc13c\ud2b8"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns2:normalized": "\ube44\ub124\uc774 \uc2a4\ud2f0\ube10 \ube48\uc13c\ud2b8 1898 1943",
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  }
+                ]
+              },
+              "ns2:xLinks": {
+                "ns2:xLink": [
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://arz.wikipedia.org/wiki/\u0633\u062a\u064a\u0641\u064a\u0646_\u06a4\u064a\u0646\u0633\u064a\u0646\u062a_\u0628\u064a\u0646\u064a\u062a"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://azb.wikipedia.org/wiki/\u0627\u0633\u062a\u06cc\u0648\u0646_\u0648\u06cc\u0646\u0633\u0646\u062a_\u0628\u0646\u062a"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://br.wikipedia.org/wiki/Stephen_V._Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://ca.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://de.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://en.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://es.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://eu.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://fa.wikipedia.org/wiki/\u0627\u0633\u062a\u06cc\u0648\u0646_\u0648\u06cc\u0646\u0633\u0646\u062a_\u0628\u0646\u062a"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://fr.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://id.wikipedia.org/wiki/Stephen_Vincent_Benet"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://it.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://ml.wikipedia.org/wiki/\u0d38\u0d4d\u0d31\u0d4d\u0d31\u0d40\u0d2b\u0d7b_\u0d35\u0d3f\u0d7b\u0d38\u0d7b\u0d31\u0d4d_\u0d2c\u0d46\u0d28\u0d46\u0d31\u0d4d\u0d31\u0d4d"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://nl.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://pl.wikipedia.org/wiki/Stephen_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://ru.wikipedia.org/wiki/\u0411\u0435\u043d\u0435,_\u0421\u0442\u0438\u0432\u0435\u043d_\u0412\u0438\u043d\u0441\u0435\u043d\u0442"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://sh.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://sv.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://sw.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t"
+                  },
+                  {
+                    "ns2:sources": {
+                      "ns2:s": "WKP",
+                      "ns2:sid": "WKP|Q1348138"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://uk.wikipedia.org/wiki/\u0421\u0442\u0456\u0432\u0435\u043d_\u0412\u0456\u043d\u0441\u0435\u043d\u0442_\u0411\u0435\u043d\u0435"
+                  }
+                ]
+              },
+              "ns2:ISBNs": {
+                "unique": 35,
+                "ns2:data": [
+                  {
+                    "count": 3,
+                    "ns2:sources": {
+                      "ns2:s": ["RERO", "SUDOC", "BNF"],
+                      "ns2:sid": [
+                        "RERO|A002992101",
+                        "SUDOC|032734816",
+                        "BNF|12370814"
+                      ]
+                    },
+                    "ns2:text": 9791096011162
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["NUKAT", "PLWABN"],
+                      "ns2:sid": [
+                        "NUKAT|n  98700739",
+                        "PLWABN|9810675783605606"
+                      ]
+                    },
+                    "ns2:text": 9788320710205
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["NUKAT", "PLWABN"],
+                      "ns2:sid": [
+                        "NUKAT|n  98700739",
+                        "PLWABN|9810675783605606"
+                      ]
+                    },
+                    "ns2:text": 9788320710182
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["W2Z", "BIBSYS"],
+                      "ns2:sid": ["W2Z|90150860", "BIBSYS|90150860"]
+                    },
+                    "ns2:text": 9788269192407
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["CAOONL", "DNB"],
+                      "ns2:sid": ["CAOONL|ncf12143156", "DNB|124803946"]
+                    },
+                    "ns2:text": 9783878780427
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "BNF"],
+                      "ns2:sid": ["LC|n  50007691", "BNF|12370814"]
+                    },
+                    "ns2:text": 9780886822941
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SUDOC"],
+                      "ns2:sid": ["LC|n  50007691", "SUDOC|032734816"]
+                    },
+                    "ns2:text": 9780836923414
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "BIBSYS"],
+                      "ns2:sid": ["LC|n  50007691", "BIBSYS|90150860"]
+                    },
+                    "ns2:text": 9780805002843
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["LNB", "NTA"],
+                      "ns2:sid": ["LNB|LNC10-000036793", "NTA|070665478"]
+                    },
+                    "ns2:text": 9780585004570
+                  },
+                  {
+                    "count": 2,
+                    "ns2:sources": {
+                      "ns2:s": ["LC", "SUDOC"],
+                      "ns2:sid": ["LC|n  50007691", "SUDOC|032734816"]
+                    },
+                    "ns2:text": 9780140437409
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "KRNLK",
+                      "ns2:sid": "KRNLK|KAC199602154"
+                    },
+                    "ns2:text": 9791192131214
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "PTBNP",
+                      "ns2:sid": "PTBNP|124245"
+                    },
+                    "ns2:text": 9789898520319
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "J9U",
+                      "ns2:sid": "J9U|987007258412405171"
+                    },
+                    "ns2:text": 9789655630831
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "SIMACOB",
+                      "ns2:sid": "SIMACOB|34977123"
+                    },
+                    "ns2:text": 9783425040066
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "LC",
+                      "ns2:sid": "LC|n  50007691"
+                    },
+                    "ns2:text": 9781945841156
+                  },
+                  {
+                    "count": 1,
+                    "ns2:sources": {
+                      "ns2:s": "SELIBR",
+                      "ns2:sid": "SELIBR|177274"
+                    },
+                    "ns2:text": 9781473315334
+                  }
+                ]
+              }
+            }
           }
-        ],
-        "normalized": "benet stephen vincent 1898 1943 amerika geschichte der usa 1944"
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP17829827"
-      }
-    },
+        },
         {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "400",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 2 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
           },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "t",
-            "#text": "Amerika"
-          },
-                    {
-            "@code": "f",
-            "#text": "1944"
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "xsi:type": "ns1:stringOrXmlFragment",
+            "ns3:VIAFCluster": {
+              "ns3:ISBNs": {
+                "ns3:data": [
+                  {
+                    "ns3:text": 9780889028708,
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": ["NUKAT", "CAOONL"],
+                      "ns3:sid": ["NUKAT|n 2004039668", "CAOONL|ncf10201615"]
+                    }
+                  },
+                  {
+                    "ns3:text": 9780061810886,
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": ["LNB", "NUKAT"],
+                      "ns3:sid": ["LNB|LNC10-000009287", "NUKAT|n 2004039668"]
+                    }
+                  },
+                  {
+                    "ns3:text": 9780897330114,
+                    "count": 1,
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  },
+                  {
+                    "ns3:text": 9780896091788,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780883059951,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780849235214,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780849202865,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780848203061,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780841417991,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780713629729,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "BIBSYS",
+                      "ns3:sid": "BIBSYS|90079854"
+                    }
+                  },
+                  {
+                    "ns3:text": 9780690671292,
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "RERO",
+                      "ns3:sid": "RERO|A002992102"
+                    }
+                  }
+                ],
+                "unique": 15
+              },
+              "ns3:history": {
+                "ns3:ht": [
+                  {
+                    "time": "2009-03-03T12:03:26+00:00",
+                    "type": "add",
+                    "recid": "DNB|118658204"
+                  },
+                  {
+                    "time": "2010-02-22T06:44:10+00:00",
+                    "type": "add",
+                    "recid": "BNF|12419859"
+                  },
+                  {
+                    "time": "2010-02-22T06:44:10+00:00",
+                    "type": "add",
+                    "recid": "LC|n  50008106"
+                  },
+                  {
+                    "time": "2010-02-22T06:44:10+00:00",
+                    "type": "add",
+                    "recid": "NKC|jn20000600804"
+                  },
+                  {
+                    "time": "2011-12-15T07:58:54+00:00",
+                    "type": "add",
+                    "recid": "SUDOC|033321035"
+                  },
+                  {
+                    "time": "2012-11-27T04:00:16+00:00",
+                    "type": "delete",
+                    "recid": "BIBSYS|x90079854"
+                  },
+                  {
+                    "time": "2012-12-19T19:11:18+00:00",
+                    "type": "add",
+                    "recid": "NTA|072895365"
+                  },
+                  {
+                    "time": "2013-05-13T19:14:22+00:00",
+                    "type": "delete",
+                    "recid": "NLIlat|000251984"
+                  },
+                  {
+                    "time": "2013-08-19T18:59:48+00:00",
+                    "type": "add",
+                    "recid": "LNB|LNC10-000009287"
+                  },
+                  {
+                    "time": "2013-09-16T16:15:07+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000110259866"
+                  },
+                  {
+                    "time": "2014-10-27T16:17:29+00:00",
+                    "type": "add",
+                    "recid": "NUKAT|n 2004039668"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "delete",
+                    "recid": "WKP|William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q2580418"
+                  },
+                  {
+                    "time": "2015-05-12T00:14:00+00:00",
+                    "type": "add",
+                    "recid": "N6I|vtls001205883"
+                  },
+                  {
+                    "time": "2015-09-20T14:54:45+00:00",
+                    "type": "add",
+                    "recid": "B2Q|0000096169"
+                  },
+                  {
+                    "time": "2016-03-21T07:38:28.834412+00:00",
+                    "type": "add",
+                    "recid": "BNCHL|10000000000000000038410"
+                  },
+                  {
+                    "time": "2016-03-21T07:38:28.843013+00:00",
+                    "type": "delete",
+                    "recid": "DNB|157362736"
+                  },
+                  {
+                    "time": "2017-04-01T11:40:56.692399+00:00",
+                    "type": "add",
+                    "recid": "BIBSYS|90079854"
+                  },
+                  {
+                    "time": "2017-06-25T15:27:11.685623+00:00",
+                    "type": "add",
+                    "recid": "NII|DA01879239"
+                  },
+                  {
+                    "time": "2017-08-20T08:45:40.217014+00:00",
+                    "type": "add",
+                    "recid": "BLBNB|000612465"
+                  },
+                  {
+                    "time": "2018-11-18T17:22:55.599505+00:00",
+                    "type": "add",
+                    "recid": "CAOONL|ncf10201615"
+                  },
+                  {
+                    "time": "2018-12-03T00:04:30.720120+00:00",
+                    "type": "delete",
+                    "recid": "LAC|0055J3206"
+                  },
+                  {
+                    "time": "2018-12-03T07:55:31.115435+00:00",
+                    "type": "delete",
+                    "recid": "LIH|LNB:YSY;=Bh"
+                  },
+                  {
+                    "time": "2018-12-03T09:59:37.083698+00:00",
+                    "type": "add",
+                    "recid": "LIH|LNB:YSY;=B_h_"
+                  },
+                  {
+                    "time": "2019-06-09T13:59:34.428136+00:00",
+                    "type": "add",
+                    "recid": "PLWABN|9810563641405606"
+                  },
+                  {
+                    "time": "2019-07-14T14:32:27.411298+00:00",
+                    "type": "delete",
+                    "recid": "NLP|a23135888"
+                  },
+                  {
+                    "time": "2020-02-02T17:53:26.071424+00:00",
+                    "type": "add",
+                    "recid": "J9U|987007301392005171"
+                  },
+                  {
+                    "time": "2020-04-12T09:57:25.947393+00:00",
+                    "type": "delete",
+                    "recid": "NLI|000251984"
+                  },
+                  {
+                    "time": "2020-06-16T21:10:44.002940+00:00",
+                    "type": "delete",
+                    "recid": "RERO|vtls002992102"
+                  },
+                  {
+                    "time": "2020-06-17T22:38:58.380965+00:00",
+                    "type": "add",
+                    "recid": "RERO|A002992102"
+                  },
+                  {
+                    "time": "2023-08-20T22:37:19.187103+00:00",
+                    "type": "add",
+                    "recid": "NLA|000035017301"
+                  },
+                  {
+                    "time": "2025-04-20T00:07:23.500563+00:00",
+                    "type": "delete",
+                    "recid": "BNE|XX1128562"
+                  }
+                ]
+              },
+              "ns3:titles": {
+                "ns3:work": [
+                  {
+                    "ns3:title": "Adolphus; or, The adopted dolphin & the pirate's daughter",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Adventures in English literature.",
+                    "ns3:sources": {
+                      "ns3:s": ["NUKAT", "LC"],
+                      "ns3:sid": ["NUKAT|n 2004039668", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "A bakers' dozen of emblems",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The Century Magazine",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "A child's garden of verses",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The chimaera.",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Columbia poetry : 1936",
+                    "ns3:sources": {
+                      "ns3:s": "NUKAT",
+                      "ns3:sid": "NUKAT|n 2004039668"
+                    }
+                  },
+                  {
+                    "ns3:title": "Connaisance de l'est.",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Dana\u00eb",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "Days of deliverance, a book of poems in wartime",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "LC"],
+                      "ns3:sid": ["SUDOC|033321035", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "Designed for reading : an Anthology drawn from The Saturday Review of Literature 1924-1934",
+                    "ns3:sources": {
+                      "ns3:s": "SUDOC",
+                      "ns3:sid": "SUDOC|033321035"
+                    }
+                  },
+                  {
+                    "ns3:title": "The dust which is God, a novel in verse",
+                    "ns3:sources": {
+                      "ns3:s": ["CAOONL", "NII", "BIBSYS", "WKP", "LC"],
+                      "ns3:sid": [
+                        "CAOONL|ncf10201615",
+                        "NII|DA01879239",
+                        "BIBSYS|90079854",
+                        "WKP|Q2580418",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "The East I know.",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NTA", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NTA|072895365",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Emblems and Electra",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Encyclopedia of world literature and the arts, with supplement",
+                    "ns3:sources": {
+                      "ns3:s": "NUKAT",
+                      "ns3:sid": "NUKAT|n 2004039668"
+                    }
+                  },
+                  {
+                    "ns3:title": "The falconer of God and other poems",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NUKAT", "NTA", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NUKAT|n 2004039668",
+                        "NTA|072895365",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Fifty poets, an American auto-anthology",
+                    "ns3:sources": {
+                      "ns3:s": ["NII", "LC"],
+                      "ns3:sid": ["NII|DA01879239", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "The first person singular.",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The flying king of Kurio; a story for children",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "From Robert & Elizabeth Browning : a further selection of the Barrett-Browning family correspondence",
+                    "ns3:sources": {
+                      "ns3:s": ["N6I", "NII", "LC"],
+                      "ns3:sid": [
+                        "N6I|vtls001205883",
+                        "NII|DA01879239",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Golden fleece; a collection of poems and ballads old and new",
+                    "ns3:sources": {
+                      "ns3:s": ["BIBSYS", "LC"],
+                      "ns3:sid": ["BIBSYS|90079854", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "Great poems of the English language, an anthology",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The great white wall, a poem",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Guide to daily reading",
+                    "ns3:sources": {
+                      "ns3:s": "PLWABN",
+                      "ns3:sid": "PLWABN|9810563641405606"
+                    }
+                  },
+                  {
+                    "ns3:title": "The Haunted Wood",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "Jesse James : for vocal quartet & piano (1950) ; Five Appalachian ballads : for voice & guitar (1958) / Lejaren Hiller. Shadows of the heart / Martin Scot Kosins",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Last poems of Elinor Wylie with other poems hitherto unpublished in book form",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "BNF"],
+                      "ns3:sid": ["SUDOC|033321035", "BNF|12419859"]
+                    }
+                  },
+                  {
+                    "ns3:title": "Lights Through the Mist",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "Merchants from Cathay ... 1913.",
+                    "ns3:sources": {
+                      "ns3:s": ["N6I", "SUDOC", "J9U", "LC"],
+                      "ns3:sid": [
+                        "N6I|vtls001205883",
+                        "SUDOC|033321035",
+                        "J9U|987007301392005171",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Moons of grandeur; a book of poems",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Mother Goose.",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Night : op. 19, no. 7",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Oeuvres choisies",
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  },
+                  {
+                    "ns3:title": "The Oxford anthology of American literature",
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "NTA",
+                        "NII",
+                        "SUDOC",
+                        "J9U",
+                        "RERO",
+                        "LC",
+                        "PLWABN",
+                        "BIBSYS"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "NTA|072895365",
+                        "NII|DA01879239",
+                        "SUDOC|033321035",
+                        "J9U|987007301392005171",
+                        "RERO|A002992102",
+                        "LC|n  50008106",
+                        "PLWABN|9810563641405606",
+                        "BIBSYS|90079854"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Paradise lost",
+                    "ns3:sources": {
+                      "ns3:s": ["NTA", "LC"],
+                      "ns3:sid": ["NTA|072895365", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "Perpetual light; a memorial",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The pocket university ...",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The poetry of freedom",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NII", "BIBSYS", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NII|DA01879239",
+                        "BIBSYS|90079854",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "A prayer for England : for men's chorus",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The prose and poetry of Elinor Wylie",
+                    "ns3:sources": {
+                      "ns3:s": ["BIBSYS", "BNF", "LC", "NTA", "SUDOC"],
+                      "ns3:sid": [
+                        "BIBSYS|90079854",
+                        "BNF|12419859",
+                        "LC|n  50008106",
+                        "NTA|072895365",
+                        "SUDOC|033321035"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "The reader's encyclopedia.",
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "WKP",
+                        "PLWABN",
+                        "NII",
+                        "BNF",
+                        "LNB",
+                        "BLBNB",
+                        "BNCHL",
+                        "LC",
+                        "B2Q",
+                        "CAOONL",
+                        "NTA",
+                        "BIBSYS",
+                        "RERO",
+                        "NKC",
+                        "SUDOC"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "WKP|Q2580418",
+                        "PLWABN|9810563641405606",
+                        "NII|DA01879239",
+                        "BNF|12419859",
+                        "LNB|LNC10-000009287",
+                        "BLBNB|000612465",
+                        "BNCHL|10000000000000000038410",
+                        "LC|n  50008106",
+                        "B2Q|0000096169",
+                        "CAOONL|ncf10201615",
+                        "NTA|072895365",
+                        "BIBSYS|90079854",
+                        "RERO|A002992102",
+                        "NKC|jn20000600804",
+                        "SUDOC|033321035"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Saturday papers, essays on literature from the Literary review; the first volume of selections from the Literary review of the New York evening post",
+                    "ns3:sources": {
+                      "ns3:s": ["BIBSYS", "LC"],
+                      "ns3:sid": ["BIBSYS|90079854", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "The Snow Queen",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "The spirit of the scene.",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NII", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NII|DA01879239",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "The stag's hornbook.",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "The stairway of surprise. [Poems.",
+                    "ns3:sources": {
+                      "ns3:s": ["NII", "LC"],
+                      "ns3:sid": ["NII|DA01879239", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "Starry harness",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Stephen Vincent Ben\u00e9t.",
+                    "ns3:sources": {
+                      "ns3:s": ["NII", "LC"],
+                      "ns3:sid": ["NII|DA01879239", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "Studies in song.",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Timothy's angels, verse;",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "Twentieth-century poetry",
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NUKAT", "NTA", "BIBSYS", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NUKAT|n 2004039668",
+                        "NTA|072895365",
+                        "BIBSYS|90079854",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:title": "Webster's new bibliographical dictionary, 1988:",
+                    "ns3:sources": {
+                      "ns3:s": "LNB",
+                      "ns3:sid": "LNB|LNC10-000009287"
+                    }
+                  },
+                  {
+                    "ns3:title": "Wild goslings; a selection of fugitive pieces",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "William Rose Ben\u00e9t literary manuscript",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "William Rose Ben\u00e9t, poems read at the City College of New York, May 8, 1938",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:title": "With wings as eagles : poems and ballads of the air",
+                    "ns3:sources": {
+                      "ns3:s": ["BIBSYS", "LC"],
+                      "ns3:sid": ["BIBSYS|90079854", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:title": "\u0421\u0435\u043d\u0447\u044a\u0440\u0438",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "\u30bb\u30f3\u30c1\u30e5\u30ea\u30fc\u30fb\u30de\u30ac\u30b8\u30f3",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:title": "\u4e16\u7eaa\u6742\u5fd7",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  }
+                ]
+              },
+              "xmlns:ns3": "http://viaf.org/viaf/terms#",
+              "ns3:Document": {
+                "about": "http://viaf.org/viaf/45096102/",
+                "ns3:inDataset": { "resource": "http://viaf.org/viaf/data" },
+                "ns3:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/45096102"
+                }
+              },
+              "ns3:birthDate": "1886-02-02",
+              "ns3:dates": {
+                "min": 191,
+                "max": 201,
+                "ns3:date": [
+                  { "scaled": 4.25, "count": 19, "content": 191 },
+                  { "scaled": 4.39, "count": 21, "content": 192 },
+                  { "scaled": 4.86, "count": 29, "content": 193 },
+                  { "scaled": 5.61, "count": 49, "content": 194 },
+                  { "scaled": 3.81, "count": 14, "content": 195 },
+                  { "scaled": 3.91, "count": 15, "content": 196 },
+                  { "scaled": 3.58, "count": 12, "content": 197 },
+                  { "scaled": 3.46, "count": 11, "content": 198 },
+                  { "scaled": 1.58, "count": 3, "content": 199 },
+                  { "scaled": 1, "count": 2, "content": 200 },
+                  { "scaled": 1, "count": 2, "content": 201 }
+                ]
+              },
+              "ns3:languageOfEntity": {
+                "ns3:data": {
+                  "ns3:text": "eng",
+                  "ns3:sources": { "ns3:s": ["BNF", "LIH"] }
+                }
+              },
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns3:x400s": {
+                "ns3:x400": [
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William R." },
+                        { "code": "d", "content": "1886-1950" }
+                      ],
+                      "ns3:normalized": "benet william r 1886 1950"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "DNB",
+                      "ns3:sid": "DNB|118658204"
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, W. R."
+                      },
+                      "ns3:normalized": "benet w r"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": ["PLWABN", "ISNI"],
+                      "ns3:sid": [
+                        "PLWABN|9810563641405606",
+                        "ISNI|0000000110259866"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William R." },
+                        { "code": "d", "content": "1886-1950" }
+                      ],
+                      "ns3:normalized": "benet william r 1886 1950"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "ISNI",
+                      "ns3:sid": "ISNI|0000000110259866"
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Rose Ben\u00e9t, William" },
+                        { "code": "d", "content": "1886-1950" }
+                      ],
+                      "ns3:normalized": "rose benet william 1886 1950"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "DNB",
+                      "ns3:sid": "DNB|118658204"
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Rose Ben\u00e9t, William" },
+                        { "code": "d", "content": "1886-1950" }
+                      ],
+                      "ns3:normalized": "rose benet william 1886 1950"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "ISNI",
+                      "ns3:sid": "ISNI|0000000110259866"
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Benet" },
+                        { "code": "c", "content": "shkrimtar amerikan" }
+                      ],
+                      "ns3:normalized": "william rose benet shkrimtar amerikan"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "William Rose Ben\u00e9t"
+                      },
+                      "ns3:normalized": "william rose benet"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "ISNI",
+                      "ns3:sid": "ISNI|0000000110259866"
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        {
+                          "code": "c",
+                          "content": "Amerikaans auteur (1886-1950)"
+                        }
+                      ],
+                      "ns3:normalized": "william rose benet amerikaans auteur 1886 1950"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": ["WKP", "ISNI"],
+                      "ns3:sid": ["WKP|Q2580418", "ISNI|0000000110259866"]
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        {
+                          "code": "c",
+                          "content": "US-amerikanischer Dichter und Herausgeber"
+                        }
+                      ],
+                      "ns3:normalized": "william rose benet us amerikanischer dichter und herausgeber"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": ["WKP", "ISNI"],
+                      "ns3:sid": ["WKP|Q2580418", "ISNI|0000000110259866"]
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        { "code": "c", "content": "americk\u00fd spisovatel" }
+                      ],
+                      "ns3:normalized": "william rose benet americky spisovatel"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        { "code": "c", "content": "escriptor estatunidenc" }
+                      ],
+                      "ns3:normalized": "william rose benet escriptor estatunidenc"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        { "code": "c", "content": "escritor estadounidense" }
+                      ],
+                      "ns3:normalized": "william rose benet escritor estadounidense"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        { "code": "c", "content": "outor merikano" }
+                      ],
+                      "ns3:normalized": "william rose benet outor merikano"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        {
+                          "code": "c",
+                          "content": "po\u00e8te, nouvelliste, romancier, essayiste, anthologiste, et \u00e9diteur am\u00e9ricain."
+                        }
+                      ],
+                      "ns3:normalized": "william rose benet poete nouvelliste romancier essayiste anthologiste et editeur americain"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        { "code": "c", "content": "scriitor american" }
+                      ],
+                      "ns3:normalized": "william rose benet scriitor american"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        { "code": "c", "content": "scrittore statunitense" }
+                      ],
+                      "ns3:normalized": "william rose benet scrittore statunitense"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        {
+                          "code": "c",
+                          "content": "scr\u00edbhneoir Meirice\u00e1nach"
+                        }
+                      ],
+                      "ns3:normalized": "william rose benet scribhneoir meiriceanach"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        {
+                          "code": "c",
+                          "content": "yhdysvaltalainen kirjailija"
+                        }
+                      ],
+                      "ns3:normalized": "william rose benet yhdysvaltalainen kirjailija"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0423\u0438\u043b\u044c\u044f\u043c \u0420\u043e\u0443\u0437 \u0411\u0435\u043d\u0435"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u0430\u043c\u0435\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u0438\u0439 \u043f\u0438\u0441\u0430\u0442\u0435\u043b\u044c"
+                        }
+                      ],
+                      "ns3:normalized": "\u0443\u0438\u043b\u044c\u044f\u043c \u0440\u043e\u0443\u0437 \u0431\u0435\u043d\u0435 \u0430\u043c\u0435\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u0438\u0438 \u043f\u0438\u0441\u0430\u0442\u0435\u043b\u044c"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "\u05d5\u05d9\u05dc\u05d9\u05d0\u05dd \u05e8\u05d5\u05d6 \u05d1\u05e0\u05d8"
+                      },
+                      "ns3:normalized": "\u05d5\u05d9\u05dc\u05d9\u05d0\u05dd \u05e8\u05d5\u05d6 \u05d1\u05e0\u05d8"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "ISNI",
+                      "ns3:sid": "ISNI|0000000110259866"
+                    }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u05d5\u05d9\u05dc\u05d9\u05d0\u05dd \u05e8\u05d5\u05d6 \u05d1\u05e0\u05d8"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u05e1\u05d5\u05e4\u05e8 \u05d0\u05de\u05e8\u05d9\u05e7\u05d0\u05d9"
+                        }
+                      ],
+                      "ns3:normalized": "\u05d5\u05d9\u05dc\u05d9\u05d0\u05dd \u05e8\u05d5\u05d6 \u05d1\u05e0\u05d8 \u05e1\u05d5\u05e4\u05e8 \u05d0\u05de\u05e8\u05d9\u05e7\u05d0\u05d9"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "\u0648\u064a\u0644\u064a\u0627\u0645 \u0631\u0648\u0633 \u0628\u064a\u0646\u064a\u062a"
+                      },
+                      "ns3:normalized": "\u0648\u064a\u0644\u064a\u0627\u0645 \u0631\u0648\u0633 \u0628\u064a\u0646\u064a\u062a"
+                    },
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  },
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns3:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0648\u06cc\u0644\u06cc\u0627\u0645 \u0631\u0632 \u0628\u0646\u062a"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u0646\u0648\u06cc\u0633\u0646\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627\u06cc\u06cc"
+                        }
+                      ],
+                      "ns3:normalized": "\u0648\u06cc\u0644\u06cc\u0627\u0645 \u0631\u0632 \u0628\u0646\u062a \u0646\u0648\u06cc\u0633\u0646\u062f\u0647 \u0627\u0645\u0631\u06cc\u06a9\u0627\u06cc\u06cc"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": ["WKP", "ISNI"],
+                      "ns3:sid": ["WKP|Q2580418", "ISNI|0000000110259866"]
+                    }
+                  }
+                ]
+              },
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns3:countries": {
+                "ns3:data": [
+                  {
+                    "scaled": 7,
+                    "ns3:text": "US",
+                    "count": 109,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "PLWABN",
+                        "BNF",
+                        "LNB",
+                        "BLBNB",
+                        "BNCHL",
+                        "LC",
+                        "B2Q",
+                        "SUDOC",
+                        "CAOONL",
+                        "RERO",
+                        "NTA",
+                        "J9U"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "PLWABN|9810563641405606",
+                        "BNF|12419859",
+                        "LNB|LNC10-000009287",
+                        "BLBNB|000612465",
+                        "BNCHL|10000000000000000038410",
+                        "LC|n  50008106",
+                        "B2Q|0000096169",
+                        "SUDOC|033321035",
+                        "CAOONL|ncf10201615",
+                        "RERO|A002992102",
+                        "NTA|072895365",
+                        "J9U|987007301392005171"
+                      ]
+                    }
+                  },
+                  {
+                    "scaled": 3,
+                    "ns3:text": "GB",
+                    "count": 9,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "N6I",
+                        "SUDOC",
+                        "BIBSYS",
+                        "RERO",
+                        "LC",
+                        "PLWABN"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "N6I|vtls001205883",
+                        "SUDOC|033321035",
+                        "BIBSYS|90079854",
+                        "RERO|A002992102",
+                        "LC|n  50008106",
+                        "PLWABN|9810563641405606"
+                      ]
+                    }
+                  },
+                  {
+                    "scaled": 1,
+                    "ns3:text": "CA",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": ["NUKAT", "CAOONL"],
+                      "ns3:sid": ["NUKAT|n 2004039668", "CAOONL|ncf10201615"]
+                    }
+                  },
+                  {
+                    "scaled": 1,
+                    "ns3:text": "KI",
+                    "count": 1,
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  }
+                ]
+              },
+              "ns3:mainHeadings": {
+                "ns3:data": [
+                  {
+                    "ns3:text": "Ben\u00e9t, William Rose, 1886-1950",
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "LIH",
+                        "ISNI",
+                        "BNF",
+                        "LNB",
+                        "BLBNB",
+                        "BNCHL",
+                        "PLWABN",
+                        "LC",
+                        "B2Q",
+                        "N6I",
+                        "DNB",
+                        "SUDOC",
+                        "CAOONL",
+                        "NKC",
+                        "NTA",
+                        "NLA",
+                        "J9U"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "LIH|LNB:YSY;=B_h_",
+                        "ISNI|0000000110259866",
+                        "BNF|12419859",
+                        "LNB|LNC10-000009287",
+                        "BLBNB|000612465",
+                        "BNCHL|10000000000000000038410",
+                        "PLWABN|9810563641405606",
+                        "LC|n  50008106",
+                        "B2Q|0000096169",
+                        "N6I|vtls001205883",
+                        "DNB|118658204",
+                        "SUDOC|033321035",
+                        "CAOONL|ncf10201615",
+                        "NKC|jn20000600804",
+                        "NTA|072895365",
+                        "NLA|000035017301",
+                        "J9U|987007301392005171"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "Ben\u00e9t, William Rose",
+                    "ns3:sources": {
+                      "ns3:s": ["NII", "BIBSYS", "RERO"],
+                      "ns3:sid": [
+                        "NII|DA01879239",
+                        "BIBSYS|90079854",
+                        "RERO|A002992102"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "William Rose Ben\u00e9t American writer (1886-1950)",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  }
+                ],
+                "ns3:mainHeadingEl": [
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Benet, William Rose," },
+                        { "code": "d", "content": "1886-1950" },
+                        { "code": 9, "content": "lat" }
+                      ]
+                    },
+                    "ns3:id": "J9U|987007301392005171",
+                    "ns3:sources": {
+                      "ns3:s": "J9U",
+                      "ns3:sid": "J9U|987007301392005171"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": "|",
+                      "ind1": " ",
+                      "dtype": "UNIMARC",
+                      "tag": 200,
+                      "ns3:subfield": [
+                        { "code": 7, "content": "ba0yba0y" },
+                        { "code": 8, "content": "fre" },
+                        { "code": 9, "content": 0 },
+                        { "code": "a", "content": "Ben\u00e9t" },
+                        { "code": "b", "content": "William Rose" },
+                        { "code": "f", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "BNF|12419859",
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": 1,
+                      "ind1": " ",
+                      "dtype": "UNIMARC",
+                      "tag": 200,
+                      "ns3:subfield": [
+                        { "code": 7, "content": "ba0yba0y" },
+                        { "code": 8, "content": "liteng" },
+                        { "code": "a", "content": "Ben\u00e9t" },
+                        { "code": "b", "content": "William Rose" },
+                        { "code": "f", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "LIH|LNB:YSY;=B_h_",
+                    "ns3:sources": {
+                      "ns3:s": "LIH",
+                      "ns3:sid": "LIH|LNB:YSY;=B_h_"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose" },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "DNB|118658204",
+                    "ns3:sources": {
+                      "ns3:s": "DNB",
+                      "ns3:sid": "DNB|118658204"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "LC|n  50008106",
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "SUDOC|033321035",
+                    "ns3:sources": {
+                      "ns3:s": "SUDOC",
+                      "ns3:sid": "SUDOC|033321035"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "CAOONL|ncf10201615",
+                    "ns3:sources": {
+                      "ns3:s": "CAOONL",
+                      "ns3:sid": "CAOONL|ncf10201615"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BIBSYS|90079854"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "NTA|072895365",
+                    "ns3:sources": {
+                      "ns3:s": "NTA",
+                      "ns3:sid": "NTA|072895365"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "NLA|000035017301",
+                    "ns3:sources": {
+                      "ns3:s": "NLA",
+                      "ns3:sid": "NLA|000035017301"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "DNB|118658204"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, William Rose"
+                      }
+                    },
+                    "ns3:id": "BIBSYS|90079854",
+                    "ns3:sources": {
+                      "ns3:s": "BIBSYS",
+                      "ns3:sid": "BIBSYS|90079854"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, William Rose"
+                      }
+                    },
+                    "ns3:id": "RERO|A002992102",
+                    "ns3:sources": {
+                      "ns3:s": "RERO",
+                      "ns3:sid": "RERO|A002992102"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "exact name" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "exact name" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "exact name" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "exact name" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "BIBSYS|90079854"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "J9U|987007301392005171"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, William Rose"
+                      }
+                    },
+                    "ns3:id": "NII|DA01879239",
+                    "ns3:sources": {
+                      "ns3:s": "NII",
+                      "ns3:sid": "NII|DA01879239"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose" },
+                        { "code": "d", "content": "(1886-1950)" }
+                      ]
+                    },
+                    "ns3:id": "PLWABN|9810563641405606",
+                    "ns3:sources": {
+                      "ns3:s": "PLWABN",
+                      "ns3:sid": "PLWABN|9810563641405606"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NKC|jn20000600804"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose" },
+                        { "code": "d", "content": "(1886-1950)." }
+                      ]
+                    },
+                    "ns3:id": "NUKAT|n 2004039668",
+                    "ns3:sources": {
+                      "ns3:s": "NUKAT",
+                      "ns3:sid": "NUKAT|n 2004039668"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact name" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "joint author" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose" },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "ISNI|0000000110259866",
+                    "ns3:sources": {
+                      "ns3:s": "ISNI",
+                      "ns3:sid": "ISNI|0000000110259866"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950." }
+                      ]
+                    },
+                    "ns3:id": "BLBNB|000612465",
+                    "ns3:sources": {
+                      "ns3:s": "BLBNB",
+                      "ns3:sid": "BLBNB|000612465"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "N6I|vtls001205883",
+                    "ns3:sources": {
+                      "ns3:s": "N6I",
+                      "ns3:sid": "N6I|vtls001205883"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "LNB|LNC10-000009287",
+                    "ns3:sources": {
+                      "ns3:s": "LNB",
+                      "ns3:sid": "LNB|LNC10-000009287"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" },
+                        { "code": 7, "content": "jn20000600804" }
+                      ]
+                    },
+                    "ns3:id": "NKC|jn20000600804",
+                    "ns3:sources": {
+                      "ns3:s": "NKC",
+                      "ns3:sid": "NKC|jn20000600804"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "BIBSYS|90079854"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "BNCHL|10000000000000000038410",
+                    "ns3:sources": {
+                      "ns3:s": "BNCHL",
+                      "ns3:sid": "BNCHL|10000000000000000038410"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "forced single date" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "exact title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "WKP|Q2580418"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "viafid" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, William Rose," },
+                        { "code": "d", "content": "1886-1950" }
+                      ]
+                    },
+                    "ns3:id": "B2Q|0000096169",
+                    "ns3:sources": {
+                      "ns3:s": "B2Q",
+                      "ns3:sid": "B2Q|0000096169"
+                    }
+                  },
+                  {
+                    "ns3:links": {
+                      "ns3:link": [
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "ISNI|0000000110259866"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "BNF|12419859"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "LNB|LNC10-000009287"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "LC|n  50008106"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "B2Q|0000096169"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "SUDOC|033321035"
+                        },
+                        {
+                          "ns3:match": { "type": "title" },
+                          "content": "RERO|A002992102"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "NTA|072895365"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "CAOONL|ncf10201615"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "LIH|LNB:YSY;=B_h_"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "NII|DA01879239"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "N6I|vtls001205883"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "J9U|987007301392005171"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "NUKAT|n 2004039668"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "NLA|000035017301"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "NKC|jn20000600804"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "PLWABN|9810563641405606"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "BLBNB|000612465"
+                        },
+                        {
+                          "ns3:match": { "type": "double date" },
+                          "content": "BNCHL|10000000000000000038410"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "DNB|118658204"
+                        },
+                        {
+                          "ns3:match": { "type": "suggested" },
+                          "content": "BIBSYS|90079854"
+                        }
+                      ]
+                    },
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "William Rose Ben\u00e9t" },
+                        {
+                          "code": "c",
+                          "content": "American writer (1886-1950)"
+                        },
+                        { "code": 9, "content": "en" }
+                      ]
+                    },
+                    "ns3:id": "WKP|Q2580418",
+                    "ns3:sources": { "ns3:s": "WKP", "ns3:sid": "WKP|Q2580418" }
+                  }
+                ]
+              },
+              "ns3:publishers": {
+                "ns3:data": [
+                  {
+                    "ns3:text": "T.Y. Crowell Co.",
+                    "count": 27,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "ISNI",
+                        "LNB",
+                        "BLBNB",
+                        "BNCHL",
+                        "B2Q",
+                        "SUDOC",
+                        "BIBSYS",
+                        "RERO",
+                        "LC",
+                        "PLWABN"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "ISNI|0000000110259866",
+                        "LNB|LNC10-000009287",
+                        "BLBNB|000612465",
+                        "BNCHL|10000000000000000038410",
+                        "B2Q|0000096169",
+                        "SUDOC|033321035",
+                        "BIBSYS|90079854",
+                        "RERO|A002992102",
+                        "LC|n  50008106",
+                        "PLWABN|9810563641405606"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "Oxford University Press",
+                    "count": 12,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "PLWABN",
+                        "J9U",
+                        "BIBSYS",
+                        "ISNI",
+                        "RERO",
+                        "LC",
+                        "SUDOC"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "PLWABN|9810563641405606",
+                        "J9U|987007301392005171",
+                        "BIBSYS|90079854",
+                        "ISNI|0000000110259866",
+                        "RERO|A002992102",
+                        "LC|n  50008106",
+                        "SUDOC|033321035"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "A. A. Knopf",
+                    "count": 12,
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NTA", "ISNI", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NTA|072895365",
+                        "ISNI|0000000110259866",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "Yale university press; [etc., etc.]",
+                    "count": 7,
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "NTA", "LC"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "NTA|072895365",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "Doubleday, Doran & company, inc.",
+                    "count": 6,
+                    "ns3:sources": {
+                      "ns3:s": ["PLWABN", "ISNI", "LC"],
+                      "ns3:sid": [
+                        "PLWABN|9810563641405606",
+                        "ISNI|0000000110259866",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "Library of Congress Magnetic Recording Laboratory",
+                    "count": 5,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "LC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:text": "Yale university press ; H. Milford",
+                    "count": 4,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "SUDOC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "SUDOC|033321035"]
+                    }
+                  },
+                  {
+                    "ns3:text": "George H. Doran company",
+                    "count": 4,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "LC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:text": "Yale university press; [etc., etc.]",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": "ISNI",
+                      "ns3:sid": "ISNI|0000000110259866"
+                    }
+                  },
+                  {
+                    "ns3:text": "Tudor publishing company",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "LC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "LC|n  50008106"]
+                    }
+                  },
+                  {
+                    "ns3:text": "J. Murray",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "N6I",
+                      "ns3:sid": "N6I|vtls001205883"
+                    }
+                  },
+                  {
+                    "ns3:text": "Fitzhenry & Whiteside",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "CAOONL",
+                      "ns3:sid": "CAOONL|ncf10201615"
+                    }
+                  },
+                  {
+                    "ns3:text": "Black",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "NKC",
+                      "ns3:sid": "NKC|jn20000600804"
+                    }
+                  },
+                  {
+                    "ns3:text": "Academy Chicago",
+                    "count": 1,
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  }
+                ]
+              },
+              "ns3:sources": {
+                "ns3:source": [
+                  { "nsid": "0000096169", "content": "B2Q|0000096169" },
+                  { "nsid": "FRBNF124198591", "content": "BNF|12419859" },
+                  {
+                    "nsid": "http://d-nb.info/gnd/118658204",
+                    "content": "DNB|118658204"
+                  },
+                  {
+                    "nsid": "0000000110259866",
+                    "content": "ISNI|0000000110259866"
+                  },
+                  { "nsid": "n50008106", "content": "LC|n  50008106" },
+                  {
+                    "nsid": "LNC10-000009287",
+                    "content": "LNB|LNC10-000009287"
+                  },
+                  { "nsid": "vtls001205883", "content": "N6I|vtls001205883" },
+                  { "nsid": "jn20000600804", "content": "NKC|jn20000600804" },
+                  { "nsid": "072895365", "content": "NTA|072895365" },
+                  { "nsid": "vtls002240802", "content": "NUKAT|n 2004039668" },
+                  { "nsid": "033321035", "content": "SUDOC|033321035" },
+                  { "nsid": "Q2580418", "content": "WKP|Q2580418" },
+                  {
+                    "nsid": "BNC10000000000000000038410",
+                    "content": "BNCHL|10000000000000000038410"
+                  },
+                  { "nsid": 90079854, "content": "BIBSYS|90079854" },
+                  { "nsid": "DA01879239", "content": "NII|DA01879239" },
+                  { "nsid": "000612465", "content": "BLBNB|000612465" },
+                  { "nsid": "ncf10201615", "content": "CAOONL|ncf10201615" },
+                  { "nsid": "LNB:YSY;=Bh", "content": "LIH|LNB:YSY;=B_h_" },
+                  {
+                    "nsid": 9810563641405606,
+                    "content": "PLWABN|9810563641405606"
+                  },
+                  {
+                    "nsid": 987007301392005171,
+                    "content": "J9U|987007301392005171"
+                  },
+                  { "nsid": "A002992102", "content": "RERO|A002992102" },
+                  { "nsid": "000035017301", "content": "NLA|000035017301" }
+                ]
+              },
+              "ns3:creationtime": "2025-04-20T07:51:14.869257+00:00",
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns3:coauthors": {
+                "ns3:data": [
+                  {
+                    "ns3:text": "Canby, Henry Seidel 1878-1961)",
+                    "count": 15,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NTA",
+                        "ISNI",
+                        "SUDOC",
+                        "BIBSYS",
+                        "LC",
+                        "PLWABN"
+                      ],
+                      "ns3:sid": [
+                        "NTA|072895365",
+                        "ISNI|0000000110259866",
+                        "SUDOC|033321035",
+                        "BIBSYS|90079854",
+                        "LC|n  50008106",
+                        "PLWABN|9810563641405606"
+                      ]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Pearson, Norman Holmes 1909-1975)",
+                    "count": 10,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "ISNI",
+                        "SUDOC",
+                        "J9U",
+                        "RERO",
+                        "PLWABN",
+                        "BIBSYS"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "ISNI|0000000110259866",
+                        "SUDOC|033321035",
+                        "J9U|987007301392005171",
+                        "RERO|A002992102",
+                        "PLWABN|9810563641405606",
+                        "BIBSYS|90079854"
+                      ]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Wylie, Elinor",
+                    "count": 9,
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "LC", "BIBSYS", "ISNI", "BNF"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "LC|n  50008106",
+                        "BIBSYS|90079854",
+                        "ISNI|0000000110259866",
+                        "BNF|12419859"
+                      ]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Morley, Christopher 1890-1957",
+                    "count": 4,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "LC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "LC|n  50008106"]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Thomas Y. Crowell Company",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": ["NUKAT", "ISNI"],
+                      "ns3:sid": ["NUKAT|n 2004039668", "ISNI|0000000110259866"]
+                    },
+                    "tag": 951
+                  },
+                  {
+                    "ns3:text": "Simpson, Winifred",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "LC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "LC|n  50008106"]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Rosenberg, Marjorie",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": ["ISNI", "LC"],
+                      "ns3:sid": ["ISNI|0000000110259866", "LC|n  50008106"]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Olivier, Edith 1872-1948",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": ["SUDOC", "BIBSYS", "BNF"],
+                      "ns3:sid": [
+                        "SUDOC|033321035",
+                        "BIBSYS|90079854",
+                        "BNF|12419859"
+                      ]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Duvoisin, Roger, 1900-1980",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Briggs, Wallace Alvin",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Wylie, Elinor (Elinor Hoyt), 1885-1928.",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "NTA",
+                      "ns3:sid": "NTA|072895365"
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Browning, Robert, 1812-1889.",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "N6I",
+                      "ns3:sid": "N6I|vtls001205883"
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns3:text": "Baker Siepmann, Katherine",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LNB",
+                      "ns3:sid": "LNB|LNC10-000009287"
+                    },
+                    "tag": 950
+                  }
+                ]
+              },
+              "ns3:deathDate": "1950-05-04",
+              "ns3:length": 2782,
+              "ns3:x500s": {
+                "ns3:x500": [
+                  {
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500,
+                      "ns3:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 4, "content": "bezf" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#familialRelationship"
+                        },
+                        { "code": "e", "content": "Beziehung familiaer" }
+                      ],
+                      "ns3:normalized": "benet stephen vincent 1898 1943"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "DNB",
+                      "ns3:sid": "DNB|118658204"
+                    }
+                  },
+                  {
+                    "viafLink": 266415900,
+                    "ns3:datafield": {
+                      "ind2": " ",
+                      "ind1": " ",
+                      "dtype": "MARC21",
+                      "tag": 551,
+                      "ns3:subfield": [
+                        { "code": "a", "content": "New York, NY" },
+                        { "code": 4, "content": "orts" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#placeOfDeath"
+                        }
+                      ],
+                      "ns3:normalized": "new york ny"
+                    },
+                    "ns3:sources": {
+                      "ns3:s": "DNB",
+                      "ns3:sid": "DNB|118658204"
+                    }
+                  }
+                ]
+              },
+              "ns3:RelatorCodes": {
+                "ns3:data": [
+                  {
+                    "ns3:text": "070",
+                    "count": 1,
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  },
+                  {
+                    "ns3:text": "080",
+                    "count": 1,
+                    "ns3:sources": { "ns3:s": "BNF", "ns3:sid": "BNF|12419859" }
+                  },
+                  {
+                    "ns3:text": "auteur",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "SUDOC",
+                      "ns3:sid": "SUDOC|033321035"
+                    }
+                  },
+                  {
+                    "ns3:text": "author",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "com",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LNB",
+                      "ns3:sid": "LNB|LNC10-000009287"
+                    }
+                  },
+                  {
+                    "ns3:text": "comp",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "ed",
+                    "count": 8,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "editeur scientifique",
+                    "count": 6,
+                    "ns3:sources": {
+                      "ns3:s": "SUDOC",
+                      "ns3:sid": "SUDOC|033321035"
+                    }
+                  },
+                  {
+                    "ns3:text": "editor",
+                    "count": 4,
+                    "ns3:sources": {
+                      "ns3:s": ["BNCHL", "J9U", "LC"],
+                      "ns3:sid": [
+                        "BNCHL|10000000000000000038410",
+                        "J9U|987007301392005171",
+                        "LC|n  50008106"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "edt",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "BIBSYS",
+                      "ns3:sid": "BIBSYS|90079854"
+                    }
+                  },
+                  {
+                    "ns3:text": "oprac",
+                    "count": 6,
+                    "ns3:sources": {
+                      "ns3:s": "NUKAT",
+                      "ns3:sid": "NUKAT|n 2004039668"
+                    }
+                  },
+                  {
+                    "ns3:text": "opracowanie",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "PLWABN",
+                      "ns3:sid": "PLWABN|9810563641405606"
+                    }
+                  },
+                  {
+                    "ns3:text": "preface",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": "SUDOC",
+                      "ns3:sid": "SUDOC|033321035"
+                    }
+                  },
+                  {
+                    "ns3:text": "red",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": ["LNB", "PLWABN"],
+                      "ns3:sid": [
+                        "LNB|LNC10-000009287",
+                        "PLWABN|9810563641405606"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "redaktor",
+                    "count": 3,
+                    "ns3:sources": {
+                      "ns3:s": "NUKAT",
+                      "ns3:sid": "NUKAT|n 2004039668"
+                    }
+                  },
+                  {
+                    "ns3:text": "traduction",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "SUDOC",
+                      "ns3:sid": "SUDOC|033321035"
+                    }
+                  },
+                  {
+                    "ns3:text": "translator",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "wstep",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "NUKAT",
+                      "ns3:sid": "NUKAT|n 2004039668"
+                    }
+                  }
+                ]
+              },
+              "ns3:nationalityOfEntity": {
+                "ns3:data": {
+                  "ns3:text": "US",
+                  "ns3:sources": {
+                    "ns3:s": ["BNF", "DNB", "ISNI", "WKP", "LIH"]
+                  }
+                }
+              },
+              "ns3:RecFormats": {
+                "ns3:data": [
+                  {
+                    "ns3:text": "am",
+                    "count": 125,
+                    "ns3:sources": {
+                      "ns3:s": [
+                        "NUKAT",
+                        "PLWABN",
+                        "BNF",
+                        "LNB",
+                        "BLBNB",
+                        "BNCHL",
+                        "LC",
+                        "B2Q",
+                        "N6I",
+                        "SUDOC",
+                        "BIBSYS",
+                        "RERO",
+                        "NKC",
+                        "NTA",
+                        "CAOONL",
+                        "J9U"
+                      ],
+                      "ns3:sid": [
+                        "NUKAT|n 2004039668",
+                        "PLWABN|9810563641405606",
+                        "BNF|12419859",
+                        "LNB|LNC10-000009287",
+                        "BLBNB|000612465",
+                        "BNCHL|10000000000000000038410",
+                        "LC|n  50008106",
+                        "B2Q|0000096169",
+                        "N6I|vtls001205883",
+                        "SUDOC|033321035",
+                        "BIBSYS|90079854",
+                        "RERO|A002992102",
+                        "NKC|jn20000600804",
+                        "NTA|072895365",
+                        "CAOONL|ncf10201615",
+                        "J9U|987007301392005171"
+                      ]
+                    }
+                  },
+                  {
+                    "ns3:text": "as",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "cm",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "dm",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "im",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "jm",
+                    "count": 2,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  },
+                  {
+                    "ns3:text": "pc",
+                    "count": 1,
+                    "ns3:sources": {
+                      "ns3:s": "LC",
+                      "ns3:sid": "LC|n  50008106"
+                    }
+                  }
+                ]
+              },
+              "ns3:nameType": "Personal",
+              "ns3:xLinks": {
+                "ns3:xLink": [
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://arz.wikipedia.org/wiki/\u0648\u064a\u0644\u064a\u0627\u0645_\u0631\u0648\u0633_\u0628\u064a\u0646\u064a\u062a"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://de.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://en.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://fa.wikipedia.org/wiki/\u0648\u06cc\u0644\u06cc\u0627\u0645_\u0631\u0632_\u0628\u0646\u062a"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://fr.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://gl.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://it.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://pl.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://ro.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://sv.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  },
+                  {
+                    "ns3:sources": {
+                      "ns3:s": "WKP",
+                      "ns3:sid": "WKP|Q2580418"
+                    },
+                    "type": "Wikipedia",
+                    "content": "https://sw.wikipedia.org/wiki/William_Rose_Ben\u00e9t"
+                  }
+                ]
+              },
+              "ns3:dateType": "lived",
+              "ns3:fixed": { "ns3:gender": "b" },
+              "ns3:viafID": 45096102
+            }
           }
-        ],
-        "normalized": "benet stephen vincent 1898 1943 amerika 1944"
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP17829827"
-      }
-    }
-  ]},
-  "birthDate": "0",
-  "deathDate": "0",
-  "dateType": "lived",
-  "languageOfEntity": {"data":   {
-    "text": "ger",
-    "sources": {"s": "XR"}
-  }},
-  "titles":   {
-    "author":     {
-      "@id": "VIAF|100260717",
-      "text": "Benét, Stephen Vincent"
-    },
-    "work":     {
-      "@id": "VIAF|307979935",
-      "title": "America"
-    }
-  },
-  "history": {"ht":   {
-    "@recid": "XR|VIAFEXP17829827",
-    "@time": "2015-03-11T21:41:54+00:00"
-  }},
-  "creationtime": "2017-08-13T09:00:17.450400+00:00"
-}
-            }}
-            ,
-            {"record":{
-            "recordSchema":"http://viaf.org/VIAFCluster",
-            "recordPacking":"json",
-            
-            "recordData":{
-  "@xmlns": "http://viaf.org/viaf/terms#",
-  "@xmlns:foaf": "http://xmlns.com/foaf/0.1/",
-  "@xmlns:owl": "http://www.w3.org/2002/07/owl#",
-  "@xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-  "@xmlns:void": "http://rdfs.org/ns/void#",
-  "viafID": "313666823",
-  "Document":   {
-    "@about": "http://viaf.org/viaf/313666823/",
-    "inDataset": {"@resource": "http://viaf.org/viaf/data"},
-    "primaryTopic": {"@resource": "http://viaf.org/viaf/313666823"}
-  },
-  "nameType": "UniformTitleExpression",
-  "sources": {"source":   {
-    "@nsid": "VIAFEXP9613053",
-    "#text": "XR|VIAFEXP9613053"
-  }},
-  "length": "11",
-  "mainHeadings":   {
-    "data":     {
-      "text": "Benét, Stephen Vincent, 1898-1943. | America | Spanish 1965",
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP9613053"
-      }
-    },
-    "mainHeadingEl":     {
-      "datafield":       {
-        "@ind1": "1",
-        "@ind2": " ",
-        "@tag": "100",
-        "@dtype": "MARC21",
-        "subfield":         [
-                    {
-            "@code": "a",
-            "#text": "Benét, Stephen Vincent,"
+        },
+        {
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 3 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
           },
-                    {
-            "@code": "d",
-            "#text": "1898-1943."
-          },
-                    {
-            "@code": "0",
-            "#text": "(viaf)100260717"
-          },
-                    {
-            "@code": "t",
-            "#text": "America"
-          },
-                    {
-            "@code": "l",
-            "#text": "Spanish"
-          },
-                    {
-            "@code": "f",
-            "#text": "1965"
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "ns4:VIAFCluster": {
+              "ns4:occupation": {
+                "ns4:data": [
+                  {
+                    "ns4:sources": { "ns4:s": "NKC" },
+                    "ns4:text": "spisovatelky"
+                  },
+                  { "ns4:sources": { "ns4:s": "NKC" }, "ns4:text": "basnirky" }
+                ]
+              },
+              "ns4:nameType": "Personal",
+              "ns4:history": {
+                "ns4:ht": [
+                  {
+                    "time": "2009-03-03T12:03:24+00:00",
+                    "type": "add",
+                    "recid": "DNB|118727974"
+                  },
+                  {
+                    "time": "2012-09-21T12:24:31+00:00",
+                    "type": "add",
+                    "recid": "NDL|00620559"
+                  },
+                  {
+                    "time": "2012-11-27T04:00:16+00:00",
+                    "type": "delete",
+                    "recid": "BIBSYS|x90620917"
+                  },
+                  {
+                    "time": "2013-05-13T19:14:22+00:00",
+                    "type": "delete",
+                    "recid": "NLIlat|000303448"
+                  },
+                  {
+                    "time": "2014-05-14T22:19:01+00:00",
+                    "type": "add",
+                    "recid": "LC|n  82214737"
+                  },
+                  {
+                    "time": "2014-05-14T22:19:01+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000082050706"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "delete",
+                    "recid": "WKP|Joy_Davidman"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q465594"
+                  },
+                  {
+                    "time": "2015-07-12T18:51:56+00:00",
+                    "type": "delete",
+                    "recid": "NLI|000303448"
+                  },
+                  {
+                    "time": "2016-08-02T06:05:03.564174+00:00",
+                    "type": "add",
+                    "recid": "NII|DA16315419"
+                  },
+                  {
+                    "time": "2016-08-11T13:17:13.588711+00:00",
+                    "type": "add",
+                    "recid": "SUDOC|194275620"
+                  },
+                  {
+                    "time": "2017-03-19T15:42:31.663284+00:00",
+                    "type": "add",
+                    "recid": "BIBSYS|90620917"
+                  },
+                  {
+                    "time": "2018-12-03T09:13:35.263685+00:00",
+                    "type": "add",
+                    "recid": "W2Z|90620917"
+                  },
+                  {
+                    "time": "2019-03-10T13:55:17.082071+00:00",
+                    "type": "delete",
+                    "recid": "SWNL|vtls005718583"
+                  },
+                  {
+                    "time": "2020-02-02T16:16:05.343380+00:00",
+                    "type": "add",
+                    "recid": "J9U|987007272530705171"
+                  },
+                  {
+                    "time": "2020-03-15T05:10:52.660532+00:00",
+                    "type": "delete",
+                    "recid": "BNF|12432014"
+                  },
+                  {
+                    "time": "2020-04-12T10:45:50.517477+00:00",
+                    "type": "delete",
+                    "recid": "NLI|000449596"
+                  },
+                  {
+                    "time": "2020-06-17T10:34:57.470416+00:00",
+                    "type": "delete",
+                    "recid": "RERO|vtls023836982"
+                  },
+                  {
+                    "time": "2020-10-11T12:49:03.047703+00:00",
+                    "type": "delete",
+                    "recid": "RERO|A023836982"
+                  },
+                  {
+                    "time": "2020-11-29T08:19:10.006983+00:00",
+                    "type": "delete",
+                    "recid": "N6I|vtls001102771"
+                  },
+                  {
+                    "time": "2022-03-06T11:39:28.467553+00:00",
+                    "type": "add",
+                    "recid": "NKC|pna20221140155"
+                  },
+                  {
+                    "time": "2022-04-21T07:57:27.042478+00:00",
+                    "type": "add",
+                    "recid": "NUKAT|n 2010172640"
+                  },
+                  {
+                    "time": "2024-08-11T01:07:35.447666+00:00",
+                    "type": "add",
+                    "recid": "SZ|118727974"
+                  }
+                ]
+              },
+              "ns4:titles": {
+                "ns4:work": [
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "J9U|987007272530705171"],
+                      "ns4:s": ["LC", "J9U"]
+                    },
+                    "ns4:title": "And God came in, c1983:"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "ns4:title": "Anya"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    },
+                    "ns4:title": "A grief observed / C. S. Lewis. - New York, cop. 1989."
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "J9U|987007272530705171"],
+                      "ns4:s": ["LC", "J9U"]
+                    },
+                    "ns4:title": "Letter to a comrade, 1938."
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "NDL|00620559",
+                      "ns4:s": "NDL"
+                    },
+                    "ns4:title": "n82214737"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["SUDOC|194275620", "LC|n  82214737"],
+                      "ns4:s": ["SUDOC", "LC"]
+                    },
+                    "ns4:title": "A naked tree : love sonnets to C. S. Lewis and other poems"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "NII|DA16315419"],
+                      "ns4:s": ["LC", "NII"]
+                    },
+                    "ns4:title": "Out of my bone : the letters of Joy Davidman"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "LC|n 2015012724"],
+                      "ns4:s": "LC"
+                    },
+                    "id": "VIAF|314897162",
+                    "ns4:title": "Poems. Selections"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["DNB|118727974", "J9U|987007272530705171"],
+                      "ns4:s": ["DNB", "J9U"]
+                    },
+                    "ns4:title": "Rauch \u00fcber dem Berg : Eine Auslegung d. 10 Gebote."
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "NDL|00620559",
+                      "ns4:s": "NDL"
+                    },
+                    "ns4:title": "Sanj\u014d no kemuri : Jikkai o meguru ichi k\u014dsatsu"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "ns4:title": "Seven poets in search of an answer: Maxwell Bodenheim, Joy Davidman, Langston Hughes, Aaron Kramer, Alfred Kreymborg, Martha Millet, Norman Rosten."
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "NDL|00620559",
+                        "SUDOC|194275620",
+                        "XR|VIAFWORK810732993",
+                        "LC|n  82214737",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["NDL", "SUDOC", "XR", "LC", "J9U"]
+                    },
+                    "id": "VIAF|308683211",
+                    "ns4:title": "Smoke on the mountain"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    },
+                    "ns4:title": "Songs and battle cries of a world at war"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "ns4:title": "They look like men"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "LC|n  82214737",
+                        "BIBSYS|90620917",
+                        "NUKAT|n 2010172640",
+                        "NII|DA16315419"
+                      ],
+                      "ns4:s": ["LC", "BIBSYS", "NUKAT", "NII"]
+                    },
+                    "ns4:title": "War poems of the United nations; three hundred poems, one hundred and fifty poets from twenty countries."
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "ns4:title": "Weeping Bay."
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["NDL|00620559", "NII|DA16315419"],
+                      "ns4:s": ["NDL", "NII"]
+                    },
+                    "ns4:title": "\u5c71\u4e0a\u306e\u7159 : \u5341\u6212\u3092\u3081\u3050\u308b\u4e00\u8003\u5bdf"
+                  }
+                ]
+              },
+              "ns4:fieldOfActivity": {
+                "ns4:data": [
+                  {
+                    "ns4:sources": { "ns4:s": "NKC" },
+                    "ns4:text": "umelecka literatura"
+                  },
+                  { "ns4:sources": { "ns4:s": "NKC" }, "ns4:text": "poezie" },
+                  {
+                    "ns4:sources": { "ns4:s": "NKC" },
+                    "ns4:text": "literarni cinnost"
+                  }
+                ]
+              },
+              "xmlns:ns4": "http://viaf.org/viaf/terms#",
+              "ns4:dateType": "lived",
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns4:fixed": { "ns4:gender": "a" },
+              "ns4:x500s": {
+                "ns4:x500": [
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ns4:normalized": "benet stephen vincent 1898 1943",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Bodenheim, Maxwell" },
+                        { "code": "d", "content": "1893-1954" }
+                      ],
+                      "ns4:normalized": "bodenheim maxwell 1893 1954",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Hughes, Langston" },
+                        { "code": "d", "content": "1902-1967" }
+                      ],
+                      "ns4:normalized": "hughes langston 1902 1967",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Kramer, Aaron" },
+                        { "code": "d", "content": "1921-1997" }
+                      ],
+                      "ns4:normalized": "kramer aaron 1921 1997",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Kreymborg, Alfred" },
+                        { "code": "d", "content": "1883-" }
+                      ],
+                      "ns4:normalized": "kreymborg alfred 1883",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Lewis, C. S." },
+                        { "code": "d", "content": "1898-1963" }
+                      ],
+                      "ns4:normalized": "lewis c s 1898 1963",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Lewis, C. S." },
+                        { "code": "d", "content": "1898-1963" },
+                        { "code": 4, "content": "bezf" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#familialRelationship"
+                        },
+                        { "code": "e", "content": "Beziehung familiaer" }
+                      ],
+                      "ns4:normalized": "lewis c s 1898 1963",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["DNB|118727974", "SZ|118727974"],
+                      "ns4:s": ["DNB", "SZ"]
+                    }
+                  },
+                  {
+                    "viafLink": 25903153,
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Millet, Martha"
+                      },
+                      "ns4:normalized": "millet martha",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Murai, Y\u014dko" },
+                        { "code": "d", "content": "1930-" }
+                      ],
+                      "ns4:normalized": "murai yoko 1930",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "viafLink": 266415900,
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "New York, NY" },
+                        { "code": 4, "content": "ortg" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#placeOfBirth"
+                        }
+                      ],
+                      "ns4:normalized": "new york ny",
+                      "ind1": " ",
+                      "dtype": "MARC21",
+                      "tag": 551
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["DNB|118727974", "SZ|118727974"],
+                      "ns4:s": ["DNB", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Rosten, Norman" },
+                        { "code": "d", "content": "1914-" }
+                      ],
+                      "ns4:normalized": "rosten norman 1914",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Yoseloff, Thomas" },
+                        { "code": "d", "content": "1913-2007" }
+                      ],
+                      "ns4:normalized": "yoseloff thomas 1913 2007",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u6751\u4e95, \u6d0b\u5b50"
+                        },
+                        { "code": "d", "content": "1930-" }
+                      ],
+                      "ns4:normalized": "\u6751\u4e3c \u6d0b\u53ea 1930",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 500
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  }
+                ]
+              },
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns4:RecFormats": {
+                "ns4:data": [
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "NDL|00620559",
+                        "BIBSYS|90620917",
+                        "J9U|987007272530705171",
+                        "DNB|118727974",
+                        "SUDOC|194275620",
+                        "LC|n  82214737",
+                        "NUKAT|n 2010172640"
+                      ],
+                      "ns4:s": [
+                        "NDL",
+                        "BIBSYS",
+                        "J9U",
+                        "DNB",
+                        "SUDOC",
+                        "LC",
+                        "NUKAT"
+                      ]
+                    },
+                    "count": 18,
+                    "ns4:text": "am"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "dm"
+                  }
+                ]
+              },
+              "ns4:countries": {
+                "ns4:data": [
+                  {
+                    "scaled": 4,
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "SUDOC|194275620",
+                        "LC|n  82214737",
+                        "NUKAT|n 2010172640"
+                      ],
+                      "ns4:s": ["SUDOC", "LC", "NUKAT"]
+                    },
+                    "count": 12,
+                    "ns4:text": "US"
+                  },
+                  {
+                    "scaled": 2,
+                    "ns4:sources": {
+                      "ns4:sid": ["DNB|118727974", "J9U|987007272530705171"],
+                      "ns4:s": ["DNB", "J9U"]
+                    },
+                    "count": 3,
+                    "ns4:text": "DE"
+                  },
+                  {
+                    "scaled": 1,
+                    "ns4:sources": {
+                      "ns4:sid": "NDL|00620559",
+                      "ns4:s": "NDL"
+                    },
+                    "count": 1,
+                    "ns4:text": "JP"
+                  },
+                  {
+                    "scaled": 1,
+                    "ns4:sources": {
+                      "ns4:sid": "SUDOC|194275620",
+                      "ns4:s": "SUDOC"
+                    },
+                    "count": 1,
+                    "ns4:text": "GB"
+                  }
+                ]
+              },
+              "ns4:deathDate": "1960-07-13",
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns4:nationalityOfEntity": {
+                "ns4:data": [
+                  {
+                    "ns4:sources": {
+                      "ns4:s": ["WKP", "W2Z", "DNB", "BIBSYS", "ISNI", "SZ"]
+                    },
+                    "ns4:text": "US"
+                  },
+                  {
+                    "ns4:sources": { "ns4:s": "NKC" },
+                    "ns4:text": "Spojen\u00e9 st\u00e1ty americk\u00e9"
+                  },
+                  { "ns4:sources": { "ns4:s": "ISNI" }, "ns4:text": "GB" }
+                ]
+              },
+              "ns4:languageOfEntity": {
+                "ns4:data": {
+                  "ns4:sources": { "ns4:s": ["DNB", "NKC", "SZ"] },
+                  "ns4:text": "eng"
+                }
+              },
+              "ns4:dates": {
+                "min": 193,
+                "ns4:date": [
+                  { "scaled": 2.58, "count": 6, "content": 193 },
+                  { "scaled": 3.32, "count": 10, "content": 194 },
+                  { "scaled": 2.32, "count": 5, "content": 195 },
+                  { "scaled": 2, "count": 4, "content": 196 },
+                  { "scaled": 2.58, "count": 6, "content": 197 },
+                  { "scaled": 3.17, "count": 9, "content": 198 },
+                  { "scaled": 1.58, "count": 3, "content": 199 },
+                  { "scaled": 2.32, "count": 5, "content": 200 },
+                  { "scaled": 1, "count": 2, "content": 201 }
+                ],
+                "max": 201
+              },
+              "ns4:sources": {
+                "ns4:source": [
+                  { "nsid": "00620559", "content": "NDL|00620559" },
+                  {
+                    "nsid": 987007272530705171,
+                    "content": "J9U|987007272530705171"
+                  },
+                  { "nsid": "Q465594", "content": "WKP|Q465594" },
+                  { "nsid": "n82214737", "content": "LC|n  82214737" },
+                  { "nsid": 90620917, "content": "W2Z|90620917" },
+                  {
+                    "nsid": "http://d-nb.info/gnd/118727974",
+                    "content": "DNB|118727974"
+                  },
+                  { "nsid": 194275620, "content": "SUDOC|194275620" },
+                  { "nsid": 90620917, "content": "BIBSYS|90620917" },
+                  {
+                    "nsid": "0000000082050706",
+                    "content": "ISNI|0000000082050706"
+                  },
+                  { "nsid": "DA16315419", "content": "NII|DA16315419" },
+                  { "nsid": "pna20221140155", "content": "NKC|pna20221140155" },
+                  { "nsid": "vtls007263958", "content": "NUKAT|n 2010172640" },
+                  {
+                    "nsid": "http://d-nb.info/gnd/118727974",
+                    "content": "SZ|118727974"
+                  }
+                ]
+              },
+              "ns4:ISBNs": {
+                "unique": 7,
+                "ns4:data": [
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["DNB|118727974", "J9U|987007272530705171"],
+                      "ns4:s": ["DNB", "J9U"]
+                    },
+                    "count": 2,
+                    "ns4:text": 9783772201387
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["SUDOC|194275620", "LC|n  82214737"],
+                      "ns4:s": ["SUDOC", "LC"]
+                    },
+                    "count": 2,
+                    "ns4:text": 9780802872883
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "NDL|00620559",
+                      "ns4:s": "NDL"
+                    },
+                    "count": 1,
+                    "ns4:text": 9784400427322
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "DNB|118727974",
+                      "ns4:s": "DNB"
+                    },
+                    "count": 1,
+                    "ns4:text": 9783922549116
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": 9780802863997
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": 9780664246808
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": 9780404538378
+                  }
+                ]
+              },
+              "ns4:creationtime": "2025-04-20T06:48:43.574765+00:00",
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns4:RelatorCodes": {
+                "ns4:data": {
+                  "ns4:sources": {
+                    "ns4:sid": "NUKAT|n 2010172640",
+                    "ns4:s": "NUKAT"
+                  },
+                  "count": 1,
+                  "ns4:text": "redaktor"
+                }
+              },
+              "ns4:length": 1349,
+              "ns4:birthDate": "1915-04-18",
+              "ns4:Document": {
+                "about": "http://viaf.org/viaf/20475479/",
+                "ns4:inDataset": { "resource": "http://viaf.org/viaf/data" },
+                "ns4:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/20475479"
+                }
+              },
+              "ns4:x400s": {
+                "ns4:x400": [
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Coy Devidmen"
+                      },
+                      "ns4:normalized": "coy devidmen",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman Lewis, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "davidman lewis joy 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Davidman, Helen Joy"
+                      },
+                      "ns4:normalized": "davidman helen joy",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "SUDOC|194275620",
+                        "LC|n  82214737",
+                        "NII|DA16315419",
+                        "ISNI|0000000082050706",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["SUDOC", "LC", "NII", "ISNI", "J9U"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Helen Joy," },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "davidman helen joy 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "NKC|pna20221140155",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["NKC", "J9U"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Davidman, Helen Joy."
+                      },
+                      "ns4:normalized": "davidman helen joy",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Helen Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "davidman helen joy 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Davidman, Joy"
+                      },
+                      "ns4:normalized": "davidman joy",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NII|DA16315419",
+                      "ns4:s": "NII"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy H." },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "davidman joy h 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy," },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "davidman joy 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "J9U|987007272530705171",
+                      "ns4:s": "J9U"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "davidman joy 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Gresham, Joy"
+                      },
+                      "ns4:normalized": "gresham joy",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "BIBSYS|90620917",
+                        "ISNI|0000000082050706",
+                        "W2Z|90620917"
+                      ],
+                      "ns4:s": ["BIBSYS", "ISNI", "W2Z"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Gresham, Joy Davidman"
+                      },
+                      "ns4:normalized": "gresham joy davidman",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "SUDOC|194275620",
+                        "LC|n  82214737",
+                        "NII|DA16315419",
+                        "ISNI|0000000082050706",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["SUDOC", "LC", "NII", "ISNI", "J9U"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Gresham, Joy Davidman," },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "gresham joy davidman 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "NKC|pna20221140155",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["NKC", "J9U"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Gresham, Joy Davidman."
+                      },
+                      "ns4:normalized": "gresham joy davidman",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Gresham, Joy Davidman" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "gresham joy davidman 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Gresham, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "gresham joy 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        {
+                          "code": "c",
+                          "content": "Americk\u00e1 b\u00e1sn\u00ed\u0159ka a spisovatelka, man\u017eelka spisovatele C. S. Lewise."
+                        }
+                      ],
+                      "ns4:normalized": "joy davidman americka basnirka a spisovatelka manzelka spisovatele c s lewise",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        {
+                          "code": "c",
+                          "content": "Amerikaans dichteres (1915-1960)"
+                        }
+                      ],
+                      "ns4:normalized": "joy davidman amerikaans dichteres 1915 1960",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        {
+                          "code": "c",
+                          "content": "Amerikal\u0131 \u015fair (1915 \u2013 1960)"
+                        }
+                      ],
+                      "ns4:normalized": "joy davidman amerikali sair 1915 1960",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "Onye na-ede uri Amerika" }
+                      ],
+                      "ns4:normalized": "joy davidman onye na ede uri amerika",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        {
+                          "code": "c",
+                          "content": "US-amerikanische Schriftstellerin"
+                        }
+                      ],
+                      "ns4:normalized": "joy davidman us amerikanische schriftstellerin",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "amerikansk poet" }
+                      ],
+                      "ns4:normalized": "joy davidman amerikansk poet",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "escrivana americana" }
+                      ],
+                      "ns4:normalized": "joy davidman escrivana americana",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "file Meirice\u00e1nach" }
+                      ],
+                      "ns4:normalized": "joy davidman file meiriceanach",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "poeta estatubatuarra" }
+                      ],
+                      "ns4:normalized": "joy davidman poeta estatubatuarra",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "poeta merikano" }
+                      ],
+                      "ns4:normalized": "joy davidman poeta merikano",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "poete amerikane" }
+                      ],
+                      "ns4:normalized": "joy davidman poete amerikane",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "poetessa estatunidenca" }
+                      ],
+                      "ns4:normalized": "joy davidman poetessa estatunidenca",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "poetessa statunitense" }
+                      ],
+                      "ns4:normalized": "joy davidman poetessa statunitense",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        { "code": "c", "content": "poetisa norte-americana" }
+                      ],
+                      "ns4:normalized": "joy davidman poetisa norte americana",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        {
+                          "code": "c",
+                          "content": "\u00e9crivaine am\u00e9ricaine"
+                        }
+                      ],
+                      "ns4:normalized": "joy davidman ecrivaine americaine",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": { "code": "a", "content": "Joy Gresham" },
+                      "ns4:normalized": "joy gresham",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Gresham" },
+                        { "code": "c", "content": "amerikansk poet" }
+                      ],
+                      "ns4:normalized": "joy gresham amerikansk poet",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Gresham" },
+                        { "code": "c", "content": "poeta d'Estaos Xun\u00edos" }
+                      ],
+                      "ns4:normalized": "joy gresham poeta destaos xunios",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Gresham" },
+                        { "code": "c", "content": "poetisa estadounidense" }
+                      ],
+                      "ns4:normalized": "joy gresham poetisa estadounidense",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Lewis, Joy Davidman"
+                      },
+                      "ns4:normalized": "lewis joy davidman",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "SUDOC|194275620",
+                        "LC|n  82214737",
+                        "NII|DA16315419",
+                        "ISNI|0000000082050706",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["SUDOC", "LC", "NII", "ISNI", "J9U"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Lewis, Joy Davidman," },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "lewis joy davidman 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "NKC|pna20221140155",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["NKC", "J9U"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Lewis, Joy Davidman."
+                      },
+                      "ns4:normalized": "lewis joy davidman",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Lewis, Joy Davidman" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "lewis joy davidman 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Lewis, Joy H." },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "lewis joy h 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Lewis, Joy Helen" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ns4:normalized": "lewis joy helen 1915 1960",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "SZ|118727974"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "SZ"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0414\u0436\u043e\u0439 \u0414\u0435\u0432\u0456\u0434\u043c\u0435\u043d"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u0430\u043c\u0435\u0440\u0438\u043a\u0430\u043d\u0441\u044c\u043a\u0430 \u043f\u043e\u0435\u0442\u0435\u0441\u0430"
+                        }
+                      ],
+                      "ns4:normalized": "\u0434\u0436\u043e\u0438 \u0434\u0435\u0432\u0456\u0434\u043c\u0435\u043d \u0430\u043c\u0435\u0440\u0438\u043a\u0430\u043d\u0441\u044c\u043a\u0430 \u043f\u043e\u0435\u0442\u0435\u0441\u0430",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u0414\u0436\u043e\u0439 \u0414\u044d\u0432\u0438\u0434\u043c\u0435\u043d"
+                      },
+                      "ns4:normalized": "\u0434\u0436\u043e\u0438 \u0434\u044d\u0432\u0438\u0434\u043c\u0435\u043d",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u0414\u0436\u043e\u0439 \u0414\u044d\u0432\u0456\u0434\u043c\u0430\u043d"
+                      },
+                      "ns4:normalized": "\u0434\u0436\u043e\u0438 \u0434\u044d\u0432\u0456\u0434\u043c\u0430\u043d",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u0414\u0436\u043e\u0439 \u0414\u044d\u0432\u0456\u0434\u043c\u044d\u043d"
+                      },
+                      "ns4:normalized": "\u0434\u0436\u043e\u0438 \u0434\u044d\u0432\u0456\u0434\u043c\u044d\u043d",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u05d2'\u05d5\u05d9 \u05d3\u05d9\u05d9\u05d5\u05d5\u05d9\u05d3\u05de\u05df"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u05de\u05e9\u05d5\u05e8\u05e8\u05ea \u05d0\u05de\u05e8\u05d9\u05e7\u05d0\u05d9\u05ea"
+                        }
+                      ],
+                      "ns4:normalized": "\u05d2\u05d5\u05d9 \u05d3\u05d9\u05d9\u05d5\u05d5\u05d9\u05d3\u05de\u05df \u05de\u05e9\u05d5\u05e8\u05e8\u05ea \u05d0\u05de\u05e8\u05d9\u05e7\u05d0\u05d9\u05ea",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u062c\u0648\u0649 \u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646"
+                      },
+                      "ns4:normalized": "\u062c\u0648\u0649 \u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u062c\u0648\u064a \u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646"
+                      },
+                      "ns4:normalized": "\u062c\u0648\u064a \u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u062c\u0648\u064a \u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u0634\u0627\u0639\u0631\u0629 \u0623\u0645\u0631\u064a\u0643\u064a\u0629"
+                        }
+                      ],
+                      "ns4:normalized": "\u062c\u0648\u064a \u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646 \u0634\u0627\u0639\u0631\u0629 \u0627\u0645\u0631\u064a\u0643\u064a\u0629",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u0d1c\u0d4b\u0d2f\u0d4d \u0d21\u0d47\u0d35\u0d3f\u0d21\u0d4d\u200c\u0d2e\u0d3e\u0d7b"
+                      },
+                      "ns4:normalized": "\u0d1c\u0d2f \u0d21\u0d35\u0d21\u0d2e\u0d7b",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u10ef\u10dd\u10d8 \u10d3\u10d4\u10d5\u10d8\u10d3\u10db\u10d4\u10dc\u10d8"
+                        },
+                        {
+                          "code": "c",
+                          "content": "\u10d0\u10db\u10d4\u10e0\u10d8\u10d9\u10d4\u10da\u10d8 \u10de\u10dd\u10d4\u10e2\u10d8"
+                        }
+                      ],
+                      "ns4:normalized": "\u10ef\u10dd\u10d8 \u10d3\u10d4\u10d5\u10d8\u10d3\u10db\u10d4\u10dc\u10d8 \u10d0\u10db\u10d4\u10e0\u10d8\u10d9\u10d4\u10da\u10d8 \u10de\u10dd\u10d4\u10e2\u10d8",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u30b8\u30e7\u30a4\u30fb\u30b0\u30ec\u30b7\u30e3\u30e0"
+                      },
+                      "ns4:normalized": "\u30b7\u30e7\u30a4 \u30af\u30ec\u30b7\u30e3\u30e0",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u30b8\u30e7\u30a4\u30fb\u30c7\u30a4\u30f4\u30a3\u30c3\u30c9\u30de\u30f3"
+                      },
+                      "ns4:normalized": "\u30b7\u30e7\u30a4 \u30c6\u30a4\u30a6\u30a3\u30c3\u30c8\u30de\u30f3",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u30b8\u30e7\u30a4\u30fb\u30c7\u30a4\u30f4\u30a3\u30c3\u30c9\u30de\u30f3"
+                      },
+                      "ns4:normalized": "\u30b7\u30e7\u30a4 \u30c6\u30a4\u30a6\u30a3\u30c3\u30c8\u30de\u30f3",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u30c7\u30a3\u30f4\u30a3\u30c3\u30c9\u30de\u30f3, \u30b8\u30e7\u30a4"
+                      },
+                      "ns4:normalized": "\u30c6\u30a3\u30a6\u30a3\u30c3\u30c8\u30de\u30f3 \u30b7\u30e7\u30a4",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["NDL|00620559", "ISNI|0000000082050706"],
+                      "ns4:s": ["NDL", "ISNI"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "\u6d77\u4f26\u00b7\u4e54\u4f9d\u00b7\u6234\u7ef4\u5fb7\u66fc"
+                      },
+                      "ns4:normalized": "\u6d77\u4f26 \u4e54\u4f9d \u6234\u7dad\u5fb3\u3b05",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": ["ISNI|0000000082050706", "WKP|Q465594"],
+                      "ns4:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u6d77\u502b\u00b7\u55ac\u4f9d\u00b7\u6234\u7dad\u5fb7\u66fc"
+                        },
+                        { "code": "c", "content": "\u7f8e\u570b\u8a69\u4eba" }
+                      ],
+                      "ns4:normalized": "\u6d77\u4f26 \u4e54\u4f9d \u6234\u7dad\u5fb3\u3b05 \u7f8e\u56ef\u8a69\u4eba",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  },
+                  {
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\uc870\uc774 \ub370\uc774\ube44\ub4dc\uba3c"
+                        },
+                        { "code": "c", "content": "\ubbf8\uad6d \uc2dc\uc778" }
+                      ],
+                      "ns4:normalized": "\uc870\uc774 \ub370\uc774\ube44\ub4dc\uba3c \ubbf8\uad6d \uc2dc\uc778",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 400
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" }
+                  }
+                ]
+              },
+              "ns4:coauthors": {
+                "ns4:data": [
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Yoseloff, Thomas, 1913-2007",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Rosten, Norman, 1914-",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Millet, Martha.",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Kreymborg, Alfred, 1883-1966.",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Kramer, Aaron, 1921-1997.",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "SUDOC|194275620",
+                      "ns4:s": "SUDOC"
+                    },
+                    "count": 1,
+                    "ns4:text": "King, Don W..",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Hughes, Langston, 1902-1967.",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    },
+                    "count": 1,
+                    "ns4:text": "Dial Press.",
+                    "tag": 951
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Bodenheim, Maxwell, 1893-1954.",
+                    "tag": 950
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Bergman, Alexander F., 1912-1941.",
+                    "tag": 950
+                  }
+                ]
+              },
+              "ns4:xLinks": {
+                "ns4:xLink": [
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://ar.wikipedia.org/wiki/\u062c\u0648\u064a_\u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://arz.wikipedia.org/wiki/\u062c\u0648\u0649_\u062f\u064a\u0641\u064a\u062f\u0645\u0627\u0646"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://cy.wikipedia.org/wiki/Helen_Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://de.wikipedia.org/wiki/Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://en.wikipedia.org/wiki/Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://es.wikipedia.org/wiki/Joy_Gresham"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://fr.wikipedia.org/wiki/Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://ml.wikipedia.org/wiki/\u0d1c\u0d4b\u0d2f\u0d4d_\u0d21\u0d47\u0d35\u0d3f\u0d21\u0d4d\u200c\u0d2e\u0d3e\u0d7b"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://nl.wikipedia.org/wiki/Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://no.wikipedia.org/wiki/Joy_Gresham"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://pl.wikipedia.org/wiki/Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://ru.wikipedia.org/wiki/\u0414\u044d\u0432\u0438\u0434\u043c\u0435\u043d,_\u0414\u0436\u043e\u0439"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://simple.wikipedia.org/wiki/Joy_Davidman"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "type": "Wikipedia",
+                    "content": "https://zh.wikipedia.org/wiki/\u6d77\u4f26\u00b7\u4e54\u4f9d\u00b7\u6234\u7ef4\u5fb7\u66fc"
+                  }
+                ]
+              },
+              "ns4:viafID": 20475479,
+              "ns4:mainHeadings": {
+                "ns4:mainHeadingEl": [
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "lccn" },
+                          "content": "NDL|00620559"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "lccn" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        },
+                        {
+                          "ns4:match": { "type": "exact title" },
+                          "content": "NII|DA16315419"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Davidman, Joy"
+                      },
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "LC|n  82214737",
+                      "ns4:s": "LC"
+                    },
+                    "ns4:id": "LC|n  82214737"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "title" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "exact title" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "exact title" },
+                          "content": "NUKAT|n 2010172640"
+                        },
+                        {
+                          "ns4:match": { "type": "viafid" },
+                          "content": "W2Z|90620917"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": {
+                        "code": "a",
+                        "content": "Davidman, Joy"
+                      },
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NII|DA16315419",
+                      "ns4:s": "NII"
+                    },
+                    "ns4:id": "NII|DA16315419"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "lccn" },
+                          "content": "NDL|00620559"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": 9, "content": "lat" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "J9U|987007272530705171",
+                      "ns4:s": "J9U"
+                    },
+                    "ns4:id": "J9U|987007272530705171"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "exact title" },
+                          "content": "NII|DA16315419"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "(1915-1960)." }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NUKAT|n 2010172640",
+                      "ns4:s": "NUKAT"
+                    },
+                    "ns4:id": "NUKAT|n 2010172640"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "DNB|118727974",
+                      "ns4:s": "DNB"
+                    },
+                    "ns4:id": "DNB|118727974"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NDL|00620559"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "ISNI|0000000082050706",
+                      "ns4:s": "ISNI"
+                    },
+                    "ns4:id": "ISNI|0000000082050706"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "forced single date" },
+                          "content": "NDL|00620559"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "forced single date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "title" },
+                          "content": "NII|DA16315419"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "BIBSYS|90620917",
+                      "ns4:s": "BIBSYS"
+                    },
+                    "ns4:id": "BIBSYS|90620917"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": { "ns4:sid": "SZ|118727974", "ns4:s": "SZ" },
+                    "ns4:id": "SZ|118727974"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "viafid" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "forced single date" },
+                          "content": "NDL|00620559"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "viafid" },
+                          "content": "NII|DA16315419"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy" },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "W2Z|90620917",
+                      "ns4:s": "W2Z"
+                    },
+                    "ns4:id": "W2Z|90620917"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy," },
+                        { "code": "d", "content": "1915-1960" },
+                        { "code": 7, "content": "pna20221140155" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NKC|pna20221140155",
+                      "ns4:s": "NKC"
+                    },
+                    "ns4:id": "NKC|pna20221140155"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "NUKAT|n 2010172640"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy," },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "SUDOC|194275620",
+                      "ns4:s": "SUDOC"
+                    },
+                    "ns4:id": "SUDOC|194275620"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "lccn" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "lccn" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "forced single date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "WKP|Q465594"
+                        },
+                        {
+                          "ns4:match": { "type": "forced single date" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "ISNI|0000000082050706"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Davidman, Joy," },
+                        { "code": "d", "content": "1915-1960" }
+                      ],
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": {
+                      "ns4:sid": "NDL|00620559",
+                      "ns4:s": "NDL"
+                    },
+                    "ns4:id": "NDL|00620559"
+                  },
+                  {
+                    "ns4:links": {
+                      "ns4:link": [
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "NDL|00620559"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "NKC|pna20221140155"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "BIBSYS|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "J9U|987007272530705171"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "W2Z|90620917"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "NUKAT|n 2010172640"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "DNB|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "double date" },
+                          "content": "SZ|118727974"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "SUDOC|194275620"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "LC|n  82214737"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "ISNI|0000000082050706"
+                        },
+                        {
+                          "ns4:match": { "type": "suggested" },
+                          "content": "NII|DA16315419"
+                        }
+                      ]
+                    },
+                    "ns4:datafield": {
+                      "ind2": " ",
+                      "ns4:subfield": [
+                        { "code": "a", "content": "Joy Davidman" },
+                        {
+                          "code": "c",
+                          "content": "American poet (1915\u20131960)"
+                        },
+                        { "code": 9, "content": "en" }
+                      ],
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    },
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "ns4:id": "WKP|Q465594"
+                  }
+                ],
+                "ns4:data": [
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "NDL|00620559",
+                        "NKC|pna20221140155",
+                        "W2Z|90620917",
+                        "NUKAT|n 2010172640",
+                        "DNB|118727974",
+                        "SZ|118727974",
+                        "SUDOC|194275620",
+                        "BIBSYS|90620917",
+                        "ISNI|0000000082050706"
+                      ],
+                      "ns4:s": [
+                        "NDL",
+                        "NKC",
+                        "W2Z",
+                        "NUKAT",
+                        "DNB",
+                        "SZ",
+                        "SUDOC",
+                        "BIBSYS",
+                        "ISNI"
+                      ]
+                    },
+                    "ns4:text": "Davidman, Joy, 1915-1960"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "LC|n  82214737",
+                        "NII|DA16315419",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["LC", "NII", "J9U"]
+                    },
+                    "ns4:text": "Davidman, Joy"
+                  },
+                  {
+                    "ns4:sources": { "ns4:sid": "WKP|Q465594", "ns4:s": "WKP" },
+                    "ns4:text": "Joy Davidman American poet (1915\u20131960)"
+                  }
+                ]
+              },
+              "ns4:publishers": {
+                "ns4:data": [
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "SUDOC|194275620",
+                        "LC|n  82214737",
+                        "ISNI|0000000082050706"
+                      ],
+                      "ns4:s": ["SUDOC", "LC", "ISNI"]
+                    },
+                    "count": 4,
+                    "ns4:text": "William B. Eerdmans Publishing Company"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "ISNI|0000000082050706"],
+                      "ns4:s": ["LC", "ISNI"]
+                    },
+                    "count": 3,
+                    "ns4:text": "Westminster Press"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "ISNI|0000000082050706"],
+                      "ns4:s": ["LC", "ISNI"]
+                    },
+                    "count": 3,
+                    "ns4:text": "The Macmillan company"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "DNB|118727974",
+                        "ISNI|0000000082050706",
+                        "J9U|987007272530705171"
+                      ],
+                      "ns4:s": ["DNB", "ISNI", "J9U"]
+                    },
+                    "count": 3,
+                    "ns4:text": "Franz"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": [
+                        "LC|n  82214737",
+                        "NUKAT|n 2010172640",
+                        "ISNI|0000000082050706"
+                      ],
+                      "ns4:s": ["LC", "NUKAT", "ISNI"]
+                    },
+                    "count": 3,
+                    "ns4:text": "Dial press"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["NDL|00620559", "ISNI|0000000082050706"],
+                      "ns4:s": ["NDL", "ISNI"]
+                    },
+                    "count": 2,
+                    "ns4:text": "\u65b0\u6559\u51fa\u7248\u793e"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["LC|n  82214737", "ISNI|0000000082050706"],
+                      "ns4:s": ["LC", "ISNI"]
+                    },
+                    "count": 2,
+                    "ns4:text": "Yale University Press"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": ["NDL|00620559", "ISNI|0000000082050706"],
+                      "ns4:s": ["NDL", "ISNI"]
+                    },
+                    "count": 2,
+                    "ns4:text": "Shinky\u014d Shuppansha"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "SUDOC|194275620",
+                      "ns4:s": "SUDOC"
+                    },
+                    "count": 1,
+                    "ns4:text": "Hodder and Staughton"
+                  },
+                  {
+                    "ns4:sources": {
+                      "ns4:sid": "DNB|118727974",
+                      "ns4:s": "DNB"
+                    },
+                    "count": 1,
+                    "ns4:text": "Claren"
+                  }
+                ]
+              }
+            },
+            "xsi:type": "ns1:stringOrXmlFragment"
           }
-        ]
-      },
-      "sources":       {
-        "s": "XR",
-        "sid": "XR|VIAFEXP9613053"
-      },
-      "id": "XR|VIAFEXP9613053"
-    }
-  },
-  "fixed": {"gender": "u"},
-  "x400s": {"x400":   {
-    "datafield":     {
-      "@ind1": "1",
-      "@ind2": " ",
-      "@tag": "400",
-      "@dtype": "MARC21",
-      "subfield":       [
-                {
-          "@code": "a",
-          "#text": "Benét, Stephen Vincent,"
         },
-                {
-          "@code": "d",
-          "#text": "1898-1943."
+        {
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 4 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
+          },
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "xsi:type": "ns1:stringOrXmlFragment",
+            "ns5:VIAFCluster": {
+              "ns5:titles": {
+                "ns5:work": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "BIBSYS|5070579",
+                        "J9U|987007274886105171",
+                        "RERO|A005721597",
+                        "LC|n  87865452",
+                        "SUDOC|242357261",
+                        "NII|DA08776573"
+                      ],
+                      "ns5:s": ["BIBSYS", "J9U", "RERO", "LC", "SUDOC", "NII"]
+                    },
+                    "ns5:title": "A book of Americans"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:title": "Buch \u00fcber Amerikaner"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Darling Ro and the Ben\u00e9t women, c2011:"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Fatapoufs & Thinifers"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "The gentle libertine"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Johnny Appleseed"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["NTA|068075022", "LC|n  87865452"],
+                      "ns5:s": ["NTA", "LC"]
+                    },
+                    "ns5:title": "The last circle : stories and poems"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "A lesson in love"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Patapoufs et Filifers. English [from old catalog]"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Portraits of three ladies (American)"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Six dead men"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:title": "Six hommes morts."
+                  }
+                ]
+              },
+              "ns5:RecFormats": {
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "NTA|068075022",
+                        "BIBSYS|5070579",
+                        "RERO|A005721597",
+                        "LC|n  87865452",
+                        "SUDOC|242357261",
+                        "DNB|1027296955"
+                      ],
+                      "ns5:s": ["NTA", "BIBSYS", "RERO", "LC", "SUDOC", "DNB"]
+                    },
+                    "ns5:text": "am",
+                    "count": 11
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "dm",
+                    "count": 6
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "jm",
+                    "count": 1
+                  }
+                ]
+              },
+              "xmlns:ns5": "http://viaf.org/viaf/terms#",
+              "ns5:x500s": {
+                "ns5:x500": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet stephen vincent 1898 1943",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" },
+                        { "code": 4, "content": "bezf" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#familialRelationship"
+                        },
+                        { "code": "e", "content": "Beziehung familiaer" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "viafLink": 376863,
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet stephen vincent",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet stephen vincent 1898 1943",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "viafLink": 24867369,
+                    "ns5:datafield": {
+                      "ns5:normalized": "kubik gail",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": { "code": "a", "content": "Kubik, Gail" },
+                      "dtype": "MARC21",
+                      "tag": 500
+                    }
+                  }
+                ]
+              },
+              "ns5:fixed": { "ns5:gender": "u" },
+              "ns5:ISBNs": {
+                "unique": 3,
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["BIBSYS|5070579", "LC|n  87865452"],
+                      "ns5:s": ["BIBSYS", "LC"]
+                    },
+                    "ns5:text": 9780805002973,
+                    "count": 2
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["BIBSYS|5070579", "LC|n  87865452"],
+                      "ns5:s": ["BIBSYS", "LC"]
+                    },
+                    "ns5:text": 9780805002843,
+                    "count": 2
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": 9780689829758,
+                    "count": 1
+                  }
+                ]
+              },
+              "ns5:publishers": {
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["ISNI|0000000114659103", "LC|n  87865452"],
+                      "ns5:s": ["ISNI", "LC"]
+                    },
+                    "ns5:text": "Farrar and Rinehart, inc.",
+                    "count": 5
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["BIBSYS|5070579", "LC|n  87865452"],
+                      "ns5:s": ["BIBSYS", "LC"]
+                    },
+                    "ns5:text": "H. Holt and company",
+                    "count": 3
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["LC|n  87865452", "SUDOC|242357261"],
+                      "ns5:s": ["LC", "SUDOC"]
+                    },
+                    "ns5:text": "Editions for the Armed Services",
+                    "count": 3
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:text": "Verl. f. Jugend u. Volk",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Margaret K. McElderry Books",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Grosset & Dunlap",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "RERO|A005721597",
+                      "ns5:s": "RERO"
+                    },
+                    "ns5:text": "Farrer and Rinehart",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Farrar, Straus and company",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:text": "Arrow Music Press",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "AR",
+                    "count": 1
+                  }
+                ]
+              },
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "ns5:dateType": "lived",
+              "ns5:covers": {
+                "ns5:data": {
+                  "ns5:sources": {
+                    "ns5:sid": ["BIBSYS|5070579", "LC|n  87865452"],
+                    "ns5:s": ["BIBSYS", "LC"]
+                  },
+                  "ns5:text": "0805002979",
+                  "count": 2
+                }
+              },
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns5:birthDate": 1900,
+              "ns5:coauthors": {
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "NTA|068075022",
+                        "RERO|A005721597",
+                        "BIBSYS|5070579",
+                        "SUDOC|242357261",
+                        "DNB|1027296955"
+                      ],
+                      "ns5:s": ["NTA", "RERO", "BIBSYS", "SUDOC", "DNB"]
+                    },
+                    "ns5:text": "Ben\u00e9t, Stephen Vincent, 1898-1943.",
+                    "count": 6,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "BIBSYS|5070579",
+                        "LC|n  87865452",
+                        "SUDOC|242357261"
+                      ],
+                      "ns5:s": ["BIBSYS", "LC", "SUDOC"]
+                    },
+                    "ns5:text": "Child, Charles",
+                    "count": 5,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Colette, 1873-1954.",
+                    "count": 3,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "London, Edwin.",
+                    "count": 2,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Wernick, Richard, 1934-",
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "University of Pennsylvania. Chamber Players.",
+                    "count": 1,
+                    "tag": 951
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "University of Illinois Contemporary Chamber Players.",
+                    "count": 1,
+                    "tag": 951
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Steeman, Stanislas-Andr\u00e9, 1908-1970.",
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:text": "Siegmeister, Elie",
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:text": "Schwenzen, Per 1899-1984",
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "Schindler, S. D.",
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "MacDonald, Royal.",
+                    "count": 1,
+                    "tag": 950
+                  }
+                ]
+              },
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns5:Document": {
+                "ns5:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/376863"
+                },
+                "about": "http://viaf.org/viaf/376863/",
+                "ns5:inDataset": { "resource": "http://viaf.org/viaf/data" }
+              },
+              "ns5:history": {
+                "ns5:ht": [
+                  {
+                    "time": "2009-03-03T12:03:32+00:00",
+                    "type": "add",
+                    "recid": "LC|n  87865452"
+                  },
+                  {
+                    "time": "2012-11-27T04:00:16+00:00",
+                    "type": "delete",
+                    "recid": "DNB|10146973X"
+                  },
+                  {
+                    "time": "2012-11-27T04:00:16+00:00",
+                    "type": "delete",
+                    "recid": "BIBSYS|x05070579"
+                  },
+                  {
+                    "time": "2012-11-27T04:00:16+00:00",
+                    "type": "add",
+                    "recid": "DNB|1027296955"
+                  },
+                  {
+                    "time": "2012-12-19T19:11:18+00:00",
+                    "type": "add",
+                    "recid": "NTA|068075022"
+                  },
+                  {
+                    "time": "2013-05-13T19:14:22+00:00",
+                    "type": "delete",
+                    "recid": "NLIlat|000489208"
+                  },
+                  {
+                    "time": "2013-09-16T16:15:07+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000114659103"
+                  },
+                  {
+                    "time": "2017-04-23T05:07:58.351221+00:00",
+                    "type": "add",
+                    "recid": "BIBSYS|5070579"
+                  },
+                  {
+                    "time": "2020-02-02T18:11:17.546454+00:00",
+                    "type": "add",
+                    "recid": "J9U|987007274886105171"
+                  },
+                  {
+                    "time": "2020-03-08T10:22:10.924956+00:00",
+                    "type": "add",
+                    "recid": "SUDOC|242357261"
+                  },
+                  {
+                    "time": "2020-04-12T10:58:45.941843+00:00",
+                    "type": "delete",
+                    "recid": "NLI|000489208"
+                  },
+                  {
+                    "time": "2020-05-10T15:13:03.821540+00:00",
+                    "type": "add",
+                    "recid": "NII|DA08776573"
+                  },
+                  {
+                    "time": "2020-06-17T02:11:46.917782+00:00",
+                    "type": "delete",
+                    "recid": "RERO|vtls005721597"
+                  },
+                  {
+                    "time": "2020-06-17T23:59:46.638395+00:00",
+                    "type": "add",
+                    "recid": "RERO|A005721597"
+                  },
+                  {
+                    "time": "2021-08-08T08:40:42.901560+00:00",
+                    "type": "add",
+                    "recid": "BNF|16315820"
+                  },
+                  {
+                    "time": "2022-01-02T21:57:40.616508+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q110038911"
+                  },
+                  {
+                    "time": "2023-08-20T23:54:02.884537+00:00",
+                    "type": "add",
+                    "recid": "NLA|000035156330"
+                  },
+                  {
+                    "time": "2023-08-27T22:38:19.883631+00:00",
+                    "type": "add",
+                    "recid": "NSK|000107923"
+                  },
+                  {
+                    "time": "2025-03-17T21:47:42.484382+00:00",
+                    "type": "add",
+                    "recid": "GRATEVE|126105"
+                  }
+                ]
+              },
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns5:sources": {
+                "ns5:source": [
+                  { "nsid": "068075022", "content": "NTA|068075022" },
+                  { "nsid": 5070579, "content": "BIBSYS|5070579" },
+                  {
+                    "nsid": 987007274886105171,
+                    "content": "J9U|987007274886105171"
+                  },
+                  { "nsid": "Q110038911", "content": "WKP|Q110038911" },
+                  { "nsid": "A005721597", "content": "RERO|A005721597" },
+                  { "nsid": "n87865452", "content": "LC|n  87865452" },
+                  { "nsid": 242357261, "content": "SUDOC|242357261" },
+                  {
+                    "nsid": "http://d-nb.info/gnd/1027296955",
+                    "content": "DNB|1027296955"
+                  },
+                  { "nsid": "DA08776573", "content": "NII|DA08776573" },
+                  { "nsid": "FRBNF163158203", "content": "BNF|16315820" },
+                  { "nsid": "000035156330", "content": "NLA|000035156330" },
+                  {
+                    "nsid": "0000000114659103",
+                    "content": "ISNI|0000000114659103"
+                  },
+                  { "nsid": "000107923", "content": "NSK|000107923" },
+                  { "nsid": 126105, "content": "GRATEVE|126105" }
+                ]
+              },
+              "ns5:x400s": {
+                "ns5:x400": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "NSK|000107923",
+                      "ns5:s": "NSK"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet eosemary carr",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Benet, Eosemary Carr"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet carr rosemary 1900 1962",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t Carr, Rosemary" },
+                        { "code": "d", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary carr",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary (Carr)"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary carr 1900",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Rosemary (Carr),"
+                        },
+                        { "code": "d", "content": "1900-" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary carr mrs",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Rosemary (Carr),"
+                        },
+                        { "code": "c", "content": "Mrs." }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "NLA|000035156330",
+                      "ns5:s": "NLA"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary carr 1900",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Rosemary Carr,"
+                        },
+                        { "code": "d", "content": "1900-" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet carr rosemary 1900 1962",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t Carr, Rosemary" },
+                        { "code": "d", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary carr 1900",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary Carr" },
+                        { "code": "d", "content": "1900-" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "J9U|987007274886105171",
+                      "ns5:s": "J9U"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary 1900",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary," },
+                        { "code": "d", "content": "1900-" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary 1900",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary" },
+                        { "code": "d", "content": "1900-" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "benet rosemary mrs",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary" },
+                        { "code": "c", "content": "Mrs" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "carr rosemary 1900 1962",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Carr, Rosemary" },
+                        { "code": "d", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "carr rosemary 1900 1962",
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Carr, Rosemary" },
+                        { "code": "d", "content": "1900-1962" },
+                        { "code": 4, "content": "nafr" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#EarlierNameOfThePerson"
+                        },
+                        { "code": "e", "content": "Frueherer Name" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "WKP|Q110038911",
+                      "ns5:s": "WKP"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "rosemary benet 1900 1962",
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Rosemary Ben\u00e9t" },
+                        { "code": "c", "content": "(1900 - 1962)" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "WKP|Q110038911",
+                      "ns5:s": "WKP"
+                    },
+                    "ns5:datafield": {
+                      "ns5:normalized": "rosemary benet 1900 1962",
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Rosemary Ben\u00e9t" },
+                        { "code": "c", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 400
+                    }
+                  }
+                ]
+              },
+              "ns5:deathDate": "1962-08-18",
+              "ns5:languageOfEntity": {
+                "ns5:data": {
+                  "ns5:sources": { "ns5:s": ["DNB", "BNF"] },
+                  "ns5:text": "eng"
+                }
+              },
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns5:RelatorCodes": {
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "comp",
+                    "count": 1
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "tr",
+                    "count": 4
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:text": "translator",
+                    "count": 1
+                  }
+                ]
+              },
+              "ns5:length": 668,
+              "ns5:nameType": "Personal",
+              "ns5:viafID": 376863,
+              "ns5:mainHeadings": {
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "LC|n  87865452",
+                        "J9U|987007274886105171",
+                        "DNB|1027296955"
+                      ],
+                      "ns5:s": ["LC", "J9U", "DNB"]
+                    },
+                    "ns5:text": "Ben\u00e9t, Rosemary, 1900-1962"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "NII|DA08776573",
+                        "RERO|A005721597",
+                        "BIBSYS|5070579",
+                        "NSK|000107923"
+                      ],
+                      "ns5:s": ["NII", "RERO", "BIBSYS", "NSK"]
+                    },
+                    "ns5:text": "Ben\u00e9t, Rosemary"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["NTA|068075022", "ISNI|0000000114659103"],
+                      "ns5:s": ["NTA", "ISNI"]
+                    },
+                    "ns5:text": "Ben\u00e9t, Rosemary Carr"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "NLA|000035156330",
+                        "BNF|16315820",
+                        "GRATEVE|126105"
+                      ],
+                      "ns5:s": ["NLA", "BNF", "GRATEVE"]
+                    },
+                    "ns5:text": "Ben\u00e9t, Rosemary, 1900-"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "SUDOC|242357261",
+                      "ns5:s": "SUDOC"
+                    },
+                    "ns5:text": "Ben\u00e9t, Rosemary Carr, 1900-1962"
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "WKP|Q110038911",
+                      "ns5:s": "WKP"
+                    },
+                    "ns5:text": "Rosemary Ben\u00e9t"
+                  }
+                ],
+                "ns5:mainHeadingEl": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "NSK|000107923",
+                      "ns5:s": "NSK"
+                    },
+                    "ns5:id": "NSK|000107923",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "NII|DA08776573"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Benet, Rosemary"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "GRATEVE|126105",
+                      "ns5:s": "GRATEVE"
+                    },
+                    "ns5:id": "GRATEVE|126105",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "DNB|1027296955"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Benet, Rosemary," },
+                        { "code": "d", "content": "1900-" },
+                        { "code": 0, "content": "urn:nbn:gr:nlg:01-A072722" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "BNF|16315820",
+                      "ns5:s": "BNF"
+                    },
+                    "ns5:id": "BNF|16315820",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126105"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": "|",
+                      "ind1": " ",
+                      "ns5:subfield": [
+                        { "code": 7, "content": "ba0yba0y" },
+                        { "code": 8, "content": "fre" },
+                        { "code": 9, "content": 0 },
+                        { "code": "a", "content": "Ben\u00e9t" },
+                        { "code": "b", "content": "Rosemary" },
+                        { "code": "f", "content": "1900-...." }
+                      ],
+                      "dtype": "UNIMARC",
+                      "tag": 200
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "NTA|068075022",
+                      "ns5:s": "NTA"
+                    },
+                    "ns5:id": "NTA|068075022",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary Carr"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "SUDOC|242357261",
+                      "ns5:s": "SUDOC"
+                    },
+                    "ns5:id": "SUDOC|242357261",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "NTA|068075022"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "NII|DA08776573"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "NLA|000035156330"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Rosemary Carr,"
+                        },
+                        { "code": "d", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "DNB|1027296955",
+                      "ns5:s": "DNB"
+                    },
+                    "ns5:id": "DNB|1027296955",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "NTA|068075022"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126105"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary" },
+                        { "code": "d", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "NLA|000035156330",
+                      "ns5:s": "NLA"
+                    },
+                    "ns5:id": "NLA|000035156330",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "SUDOC|242357261"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary," },
+                        { "code": "d", "content": "1900-" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "J9U|987007274886105171",
+                      "ns5:s": "J9U"
+                    },
+                    "ns5:id": "J9U|987007274886105171",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126105"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "NII|DA08776573"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary," },
+                        { "code": "d", "content": "1900-1962" },
+                        { "code": 9, "content": "lat" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "LC|n  87865452",
+                      "ns5:s": "LC"
+                    },
+                    "ns5:id": "LC|n  87865452",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "NTA|068075022"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "NII|DA08776573"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "NLA|000035156330"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, Rosemary," },
+                        { "code": "d", "content": "1900-1962" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "RERO|A005721597",
+                      "ns5:s": "RERO"
+                    },
+                    "ns5:id": "RERO|A005721597",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "NTA|068075022"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "NSK|000107923"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "joint author" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "NII|DA08776573"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "BIBSYS|5070579",
+                      "ns5:s": "BIBSYS"
+                    },
+                    "ns5:id": "BIBSYS|5070579",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "NTA|068075022"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "GRATEVE|126105"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "NSK|000107923"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "NII|DA08776573"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "NLA|000035156330"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "J9U|987007274886105171"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "NII|DA08776573",
+                      "ns5:s": "NII"
+                    },
+                    "ns5:id": "NII|DA08776573",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "RERO|A005721597"
+                        },
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "NSK|000107923"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "exact title" },
+                          "content": "SUDOC|242357261"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "ISNI|0000000114659103",
+                      "ns5:s": "ISNI"
+                    },
+                    "ns5:id": "ISNI|0000000114659103",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "exact name" },
+                          "content": "NTA|068075022"
+                        },
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "WKP|Q110038911"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "double date" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "NLA|000035156330"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns5:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Rosemary Carr"
+                      },
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": "WKP|Q110038911",
+                      "ns5:s": "WKP"
+                    },
+                    "ns5:id": "WKP|Q110038911",
+                    "ns5:links": {
+                      "ns5:link": [
+                        {
+                          "ns5:match": { "type": "viafid" },
+                          "content": "BIBSYS|5070579"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "J9U|987007274886105171"
+                        },
+                        {
+                          "ns5:match": { "type": "forced single date" },
+                          "content": "GRATEVE|126105"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "LC|n  87865452"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "SUDOC|242357261"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "DNB|1027296955"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "BNF|16315820"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        },
+                        {
+                          "ns5:match": { "type": "suggested" },
+                          "content": "ISNI|0000000114659103"
+                        }
+                      ]
+                    },
+                    "ns5:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns5:subfield": [
+                        { "code": "a", "content": "Rosemary Ben\u00e9t" },
+                        { "code": 9, "content": "fr" },
+                        { "code": 9, "content": "nl" },
+                        { "code": 9, "content": "pt" },
+                        { "code": 9, "content": "it" },
+                        { "code": 9, "content": "sv" },
+                        { "code": 9, "content": "pt-br" },
+                        { "code": 9, "content": "gl" },
+                        { "code": 9, "content": "es" }
+                      ],
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  }
+                ]
+              },
+              "ns5:creationtime": "2025-04-20T06:55:16.950942+00:00",
+              "ns5:dates": {
+                "min": 193,
+                "max": 201,
+                "ns5:date": [
+                  { "scaled": 3, "count": 8, "content": 193 },
+                  { "scaled": 3.17, "count": 9, "content": 194 },
+                  { "scaled": 1, "count": 2, "content": 195 },
+                  { "scaled": 0, "count": 1, "content": 196 },
+                  { "scaled": 1, "count": 2, "content": 197 },
+                  { "scaled": 2.81, "count": 7, "content": 198 },
+                  { "scaled": 0, "count": 1, "content": 199 },
+                  { "scaled": 1, "count": 2, "content": 200 },
+                  { "scaled": 0, "count": 1, "content": 201 }
+                ]
+              },
+              "ns5:countries": {
+                "ns5:data": [
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": [
+                        "NTA|068075022",
+                        "RERO|A005721597",
+                        "LC|n  87865452",
+                        "SUDOC|242357261"
+                      ],
+                      "ns5:s": ["NTA", "RERO", "LC", "SUDOC"]
+                    },
+                    "ns5:text": "US",
+                    "scaled": 4,
+                    "count": 15
+                  },
+                  {
+                    "ns5:sources": {
+                      "ns5:sid": ["LC|n  87865452", "DNB|1027296955"],
+                      "ns5:s": ["LC", "DNB"]
+                    },
+                    "ns5:text": "DE",
+                    "scaled": 1,
+                    "count": 2
+                  }
+                ]
+              },
+              "ns5:nationalityOfEntity": {
+                "ns5:data": {
+                  "ns5:sources": { "ns5:s": ["DNB", "BNF", "ISNI"] },
+                  "ns5:text": "US"
+                }
+              }
+            }
+          }
         },
-                {
-          "@code": "t",
-          "#text": "Historia sucinta de los Estados Unidos"
+        {
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 5 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
+          },
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "xsi:type": "ns1:stringOrXmlFragment",
+            "ns6:VIAFCluster": {
+              "ns6:titles": {
+                "ns6:work": [
+                  {
+                    "ns6:title": "The devil and Daniel Webster",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:title": "Electro-ballistic machines, and the Schultz' chronoscope.",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:title": "Metallic ammunition for the Springfield breech-loading rifle-musket. Prepared under the direction of the chief of ordnance",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:title": "Ordnance and artillery.",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:title": "Organization of the Ordnance department and the reasons for its separation from the line of the Army.",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:title": "The political and military history of the Campaign of Waterloo",
+                    "ns6:sources": {
+                      "ns6:s": ["N6I", "PLWABN", "LC"],
+                      "ns6:sid": [
+                        "N6I|vtls000040077",
+                        "PLWABN|9810561542805606",
+                        "LC|n  87806607"
+                      ]
+                    }
+                  },
+                  {
+                    "ns6:title": "Regulations for the care, preservation, and accountability of ordnance and ordnance stores; with instructions for making the returns, reports, etc., prescribed by the Chief of Ordnance, U. S.  Army, under the provisions of section 1167, Revised statutes of the United States.  For the use of the troops in the military service of the United States.",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:title": "Report of the Board on Fortifications or Other Defenses appointed by the President of the United States under the provisions of the act of Congress approved March 3, 1885 ...",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:title": "A treatise on military law and the practice of courts-martial.",
+                    "ns6:sources": {
+                      "ns6:s": ["N6I", "LC"],
+                      "ns6:sid": ["N6I|vtls000040077", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "ns6:title": "\u05d4\u05e9\u05d8\u05df \u05d5\u05d3\u05e0\u05d9\u05d0\u05dc \u05d5\u05d1\u05e1\u05d8\u05e8 ; \u05d0\u05e8\u05d5\u05db\u05d4 \u05d4\u05d3\u05e8\u05da \u05dc\u05d7\u05e8\u05d5\u05ea ; \u05d9\u05e2\u05e7\u05d1 \u05d5\u05d4\u05d0\u05d9\u05e0\u05d3\u05d9\u05d0\u05e0\u05d9\u05dd",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:title": "\u0627\u0645\u0631\u064a\u0643\u0627",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  }
+                ]
+              },
+              "ns6:Document": {
+                "ns6:inDataset": { "resource": "http://viaf.org/viaf/data" },
+                "about": "http://viaf.org/viaf/100260729/",
+                "ns6:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/100260729"
+                }
+              },
+              "ns6:x400s": {
+                "ns6:x400": [
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent",
+                      "dtype": "MARC21",
+                      "ns6:subfield": {
+                        "code": "a",
+                        "content": "Benet, Stephen Vincent"
+                      },
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "PLWABN",
+                      "ns6:sid": "PLWABN|9810561542805606"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent 1827 1895",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "CAOONL",
+                      "ns6:sid": "CAOONL|ncf11670909"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": 0,
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent 1827 1895",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent",
+                      "dtype": "MARC21",
+                      "ns6:subfield": {
+                        "code": "a",
+                        "content": "Ben\u00e9t, Stephen Vincent"
+                      },
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "ISNI",
+                      "ns6:sid": "ISNI|0000000400231597"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent 1827 1895",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": 0,
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent 1827 1895",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent,"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "N6I",
+                      "ns6:sid": "N6I|vtls000040077"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "benet stephen vincent 1827 1895",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "ISNI",
+                      "ns6:sid": "ISNI|0000000400231597"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns6:normalized": "stephen vincent benet 8th chief of ordnance for the u s army ordnance corps",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "8th Chief of Ordnance for the U.S. Army Ordnance Corps"
+                        }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns6:normalized": "stephen vincent benet general der united states army",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Stephen Vincent Ben\u00e9t"
+                        },
+                        {
+                          "code": "c",
+                          "content": "General der United States Army"
+                        }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "\u05d1\u05e0\u05d4 \u05e1\u05d8\u05d9\u05d1\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8",
+                      "dtype": "MARC21",
+                      "ns6:subfield": {
+                        "code": "a",
+                        "content": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05d9\u05d1\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8"
+                      },
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "\u05d1\u05e0\u05d4 \u05e1\u05d8\u05e4\u05df \u05d5\u05d5\u05d9\u05e0\u05e6\u05e0\u05d8 1898 1943",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05e4\u05df \u05d5\u05d5\u05d9\u05e0\u05e6\u05e0\u05d8,"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "\u05d1\u05e0\u05d4 \u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8 1827 1895",
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "ISNI",
+                      "ns6:sid": "ISNI|0000000400231597"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns6:normalized": "\u05d1\u05e0\u05d9 \u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8",
+                      "dtype": "MARC21",
+                      "ns6:subfield": {
+                        "code": "a",
+                        "content": "\u05d1\u05e0\u05d9, \u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8"
+                      },
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns6:normalized": "\u0628\u0646\u064a\u0647 \u0633\u062a\u064a\u06a4\u0646 \u06a4\u0646\u0633\u0646\u062a",
+                      "dtype": "MARC21",
+                      "ns6:subfield": {
+                        "code": "a",
+                        "content": "\u0628\u0646\u064a\u0647\u060c \u0633\u062a\u064a\u06a4\u0646 \u06a4\u0646\u0633\u0646\u062a"
+                      },
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "ISNI",
+                      "ns6:sid": "ISNI|0000000400231597"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns6:normalized": "\u30b9\u30c6\u30a3\u30d5\u30f3 \u30d2\u30f3\u30bb\u30f3\u30c8 \u30d8\u30cd\u30c3\u30c8",
+                      "dtype": "MARC21",
+                      "ns6:subfield": {
+                        "code": "a",
+                        "content": "\u30b9\u30c6\u30a3\u30fc\u30d6\u30f3\u30fb\u30d3\u30f3\u30bb\u30f3\u30c8\u30fb\u30d9\u30cd\u30c3\u30c8"
+                      },
+                      "tag": 400
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    }
+                  }
+                ]
+              },
+              "xmlns:ns6": "http://viaf.org/viaf/terms#",
+              "ns6:deathDate": "1895-01-22",
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "ns6:countries": {
+                "ns6:data": [
+                  {
+                    "scaled": 4,
+                    "count": 15,
+                    "ns6:text": "US",
+                    "ns6:sources": {
+                      "ns6:s": ["N6I", "PLWABN", "LC"],
+                      "ns6:sid": [
+                        "N6I|vtls000040077",
+                        "PLWABN|9810561542805606",
+                        "LC|n  87806607"
+                      ]
+                    }
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 2,
+                    "ns6:text": "IL",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "scaled": 1,
+                    "count": 1,
+                    "ns6:text": "EG",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  }
+                ]
+              },
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns6:dates": {
+                "min": 185,
+                "ns6:date": [
+                  { "scaled": 2.32, "count": 5, "content": 185 },
+                  { "scaled": 3.81, "count": 14, "content": 186 },
+                  { "scaled": 2.58, "count": 6, "content": 187 },
+                  { "scaled": 1.58, "count": 3, "content": 188 },
+                  { "scaled": 1, "count": 2, "content": 189 },
+                  { "scaled": 1, "count": 2, "content": 190 },
+                  { "scaled": 1, "count": 2, "content": 191 },
+                  { "scaled": 1, "count": 2, "content": 192 },
+                  { "scaled": 1, "count": 2, "content": 193 },
+                  { "scaled": 1.58, "count": 3, "content": 194 },
+                  { "scaled": 1, "count": 2, "content": 195 },
+                  { "scaled": 1.58, "count": 3, "content": 196 },
+                  { "scaled": 1.58, "count": 3, "content": 197 }
+                ],
+                "max": 197
+              },
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns6:history": {
+                "ns6:ht": [
+                  {
+                    "time": "2010-11-16T05:07:56+00:00",
+                    "type": "delete",
+                    "recid": "BNE|XX981097"
+                  },
+                  {
+                    "time": "2013-02-15T19:30:59+00:00",
+                    "type": "add",
+                    "recid": "LC|n  87806607"
+                  },
+                  {
+                    "time": "2013-05-13T19:14:22+00:00",
+                    "type": "delete",
+                    "recid": "NLIlat|000018788"
+                  },
+                  {
+                    "time": "2013-05-13T19:14:22+00:00",
+                    "type": "delete",
+                    "recid": "NLIheb|000168369"
+                  },
+                  {
+                    "time": "2013-09-16T16:15:07+00:00",
+                    "type": "delete",
+                    "recid": "DNB|101172699"
+                  },
+                  {
+                    "time": "2014-05-14T22:19:01+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000400231597"
+                  },
+                  {
+                    "time": "2015-05-12T00:14:00+00:00",
+                    "type": "add",
+                    "recid": "N6I|vtls000040077"
+                  },
+                  {
+                    "time": "2019-06-09T13:12:28.255354+00:00",
+                    "type": "add",
+                    "recid": "PLWABN|9810561542805606"
+                  },
+                  {
+                    "time": "2019-07-14T14:55:04.385344+00:00",
+                    "type": "delete",
+                    "recid": "NLP|a24478921"
+                  },
+                  {
+                    "time": "2020-02-02T17:00:26.519647+00:00",
+                    "type": "add",
+                    "recid": "J9U|987007258412605171"
+                  },
+                  {
+                    "time": "2020-04-12T08:53:39.631474+00:00",
+                    "type": "delete",
+                    "recid": "NLI|000018788"
+                  },
+                  {
+                    "time": "2020-07-14T14:14:10.121078+00:00",
+                    "type": "add",
+                    "recid": "CAOONL|ncf11670909"
+                  },
+                  {
+                    "time": "2022-07-24T09:51:25.550532+00:00",
+                    "type": "delete",
+                    "recid": "WKP|Q94520226"
+                  },
+                  {
+                    "time": "2022-07-24T12:19:36.158443+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q43375723"
+                  }
+                ]
+              },
+              "ns6:publishers": {
+                "ns6:data": [
+                  {
+                    "count": 9,
+                    "ns6:text": "D. Van Nostrand",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 4,
+                    "ns6:text": "Redfield",
+                    "ns6:sources": {
+                      "ns6:s": ["N6I", "ISNI", "LC"],
+                      "ns6:sid": [
+                        "N6I|vtls000040077",
+                        "ISNI|0000000400231597",
+                        "LC|n  87806607"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "ns6:text": "\u0645\u0643\u062a\u0628 \u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0644\u0644\u0627\u0633\u062a\u0639\u0644\u0627\u0645\u0627\u062a\u060c",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "ns6:text": "\u05e7\u05e6\u05d9\u05df \u05d7\u05d9\u05e0\u05d5\u05da \u05e8\u05d0\u05e9\u05d9 - \u05e2\u05e0\u05e3 \u05d4\u05e9\u05db\u05dc\u05d4 - \u05de\u05e9\u05e8\u05d3 \u05d4\u05d1\u05d8\u05d7\u05d5\u05df",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "ns6:text": "Refield",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "PLWABN"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "PLWABN|9810561542805606"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "ns6:text": "J.J. O'Reilly",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "ns6:text": "Govt. Print. Off.",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 1,
+                    "ns6:text": "Yehud Comprehensive High School",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  }
+                ]
+              },
+              "ns6:RelatorCodes": {
+                "ns6:data": [
+                  {
+                    "count": 1,
+                    "ns6:text": "tl",
+                    "ns6:sources": {
+                      "ns6:s": "PLWABN",
+                      "ns6:sid": "PLWABN|9810561542805606"
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "ns6:text": "tr",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  }
+                ]
+              },
+              "ns6:nameType": "Personal",
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns6:length": 290,
+              "ns6:fixed": { "ns6:gender": "b" },
+              "ns6:xLinks": {
+                "ns6:xLink": [
+                  {
+                    "type": "Wikipedia",
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    },
+                    "content": "https://de.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t_(General)"
+                  },
+                  {
+                    "type": "Wikipedia",
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    },
+                    "content": "https://en.wikipedia.org/wiki/Stephen_Vincent_Ben\u00e9t_(general)"
+                  }
+                ]
+              },
+              "ns6:RecFormats": {
+                "ns6:data": [
+                  {
+                    "count": 14,
+                    "ns6:text": "am",
+                    "ns6:sources": {
+                      "ns6:s": ["N6I", "PLWABN", "J9U", "LC"],
+                      "ns6:sid": [
+                        "N6I|vtls000040077",
+                        "PLWABN|9810561542805606",
+                        "J9U|987007258412605171",
+                        "LC|n  87806607"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 7,
+                    "ns6:text": "dm",
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  }
+                ]
+              },
+              "ns6:coauthors": {
+                "ns6:data": [
+                  {
+                    "count": 5,
+                    "tag": 950,
+                    "ns6:text": "Jomini, Antoine Henri baron de, 1779-1869.",
+                    "ns6:sources": {
+                      "ns6:s": ["N6I", "ISNI", "LC"],
+                      "ns6:sid": [
+                        "N6I|vtls000040077",
+                        "ISNI|0000000400231597",
+                        "LC|n  87806607"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 3,
+                    "tag": 951,
+                    "ns6:text": "United States. Congress. House. Committee on Military Affairs",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 3,
+                    "tag": 951,
+                    "ns6:text": "United States. Army. Ordnance Dept",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 3,
+                    "tag": 951,
+                    "ns6:text": "United States. Army. Ordnance Department",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "tag": 950,
+                    "ns6:text": "\u05e1\u05d5\u05d0\u05df, \u05d3\u05df, 1933-",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "tag": 950,
+                    "ns6:text": "\u05d1\u05df \u05e6\u05d1\u05d9, \u05d0.",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "tag": 950,
+                    "ns6:text": "\u05d0\u05dc\u05de\u05d5\u05d2, \u05e8\u05d5\u05ea, 1936-",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "J9U"],
+                      "ns6:sid": [
+                        "ISNI|0000000400231597",
+                        "J9U|987007258412605171"
+                      ]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "tag": 951,
+                    "ns6:text": "United States. Board on Fortifications or Other Defenses",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 2,
+                    "tag": 950,
+                    "ns6:text": "Sampson, William Thomas 1840-1902",
+                    "ns6:sources": {
+                      "ns6:s": ["ISNI", "LC"],
+                      "ns6:sid": ["ISNI|0000000400231597", "LC|n  87806607"]
+                    }
+                  },
+                  {
+                    "count": 1,
+                    "tag": 950,
+                    "ns6:text": "\u0639\u0628\u062f \u0627\u0644\u0645\u062c\u064a\u062f\u060c \u0639\u0628\u062f \u0627\u0644\u0639\u0632\u064a\u0632.",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "count": 1,
+                    "tag": 950,
+                    "ns6:text": "Jomini, Antoine Henri de, (1779-1869)",
+                    "ns6:sources": {
+                      "ns6:s": "PLWABN",
+                      "ns6:sid": "PLWABN|9810561542805606"
+                    }
+                  }
+                ]
+              },
+              "ns6:creationtime": "2025-04-20T03:22:10.483374+00:00",
+              "ns6:mainHeadings": {
+                "ns6:data": [
+                  {
+                    "ns6:text": "Ben\u00e9t, S. V. (Stephen Vincent), 1827-1895",
+                    "ns6:sources": {
+                      "ns6:s": ["CAOONL", "N6I", "J9U", "LC"],
+                      "ns6:sid": [
+                        "CAOONL|ncf11670909",
+                        "N6I|vtls000040077",
+                        "J9U|987007258412605171",
+                        "LC|n  87806607"
+                      ]
+                    }
+                  },
+                  {
+                    "ns6:text": "\u0628\u0646\u064a\u0647\u060c \u0633\u062a\u064a\u06a4\u0646 \u06a4\u0646\u0633\u0646\u062a",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:text": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8, 1827-1895",
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:text": "Ben\u00e9t, Stephen Vincent 1827-1895",
+                    "ns6:sources": {
+                      "ns6:s": "ISNI",
+                      "ns6:sid": "ISNI|0000000400231597"
+                    }
+                  },
+                  {
+                    "ns6:text": "Ben\u00e9t, S. V. (1827-1895)",
+                    "ns6:sources": {
+                      "ns6:s": "PLWABN",
+                      "ns6:sid": "PLWABN|9810561542805606"
+                    }
+                  },
+                  {
+                    "ns6:text": "Stephen Vincent Benet",
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    }
+                  }
+                ],
+                "ns6:mainHeadingEl": [
+                  {
+                    "ns6:datafield": {
+                      "ind2": 0,
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, S. V." },
+                        { "code": "q", "content": "(Stephen Vincent)," },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "LC|n  87806607",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "WKP|Q43375723"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "CAOONL|ncf11670909"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "LC",
+                      "ns6:sid": "LC|n  87806607"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, S. V." },
+                        { "code": "q", "content": "(Stephen Vincent)," },
+                        { "code": "d", "content": "1827-1895" },
+                        { "code": 9, "content": "lat" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "J9U|987007258412605171",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "WKP|Q43375723"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "LC|n  87806607"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "CAOONL|ncf11670909"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, S. V." },
+                        { "code": "q", "content": "(Stephen Vincent)," },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "CAOONL|ncf11670909",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "LC|n  87806607"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "CAOONL",
+                      "ns6:sid": "CAOONL|ncf11670909"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, S. V." },
+                        { "code": "d", "content": "(1827-1895)" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "PLWABN|9810561542805606",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "viafid" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "viafid" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "viafid" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "viafid" },
+                          "content": "WKP|Q43375723"
+                        },
+                        {
+                          "ns6:match": { "type": "viafid" },
+                          "content": "LC|n  87806607"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "CAOONL|ncf11670909"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "PLWABN",
+                      "ns6:sid": "PLWABN|9810561542805606"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": 0,
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        { "code": "a", "content": "Ben\u00e9t, S. V." },
+                        { "code": "q", "content": "(Stephen Vincent)," },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "N6I|vtls000040077",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "CAOONL|ncf11670909"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "LC|n  87806607"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "N6I",
+                      "ns6:sid": "N6I|vtls000040077"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1827-1895" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "ISNI|0000000400231597",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "WKP|Q43375723"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "LC|n  87806607"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "CAOONL|ncf11670909"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "J9U|987007258412605171"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "ISNI",
+                      "ns6:sid": "ISNI|0000000400231597"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        { "code": "a", "content": "Stephen Vincent Benet" },
+                        { "code": 9, "content": "nl" },
+                        { "code": 9, "content": "ast" },
+                        { "code": 9, "content": "ca" },
+                        { "code": 9, "content": "es" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "WKP|Q43375723",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "viafid" },
+                          "content": "PLWABN|9810561542805606"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "J9U|987007258412605171"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "LC|n  87806607"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "WKP",
+                      "ns6:sid": "WKP|Q43375723"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u05d1\u05e0\u05d4, \u05e1\u05d8\u05e4\u05df \u05d5\u05d9\u05e0\u05e1\u05e0\u05d8,"
+                        },
+                        { "code": "d", "content": "1827-1895" },
+                        { "code": 9, "content": "heb" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "J9U|987007258412605171",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "WKP|Q43375723"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "LC|n  87806607"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "CAOONL|ncf11670909"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  },
+                  {
+                    "ns6:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns6:subfield": [
+                        {
+                          "code": "a",
+                          "content": "\u0628\u0646\u064a\u0647\u060c \u0633\u062a\u064a\u06a4\u0646 \u06a4\u0646\u0633\u0646\u062a"
+                        },
+                        { "code": 9, "content": "ara" }
+                      ],
+                      "tag": 100
+                    },
+                    "ns6:id": "J9U|987007258412605171",
+                    "ns6:links": {
+                      "ns6:link": [
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "ISNI|0000000400231597"
+                        },
+                        {
+                          "ns6:match": { "type": "forced single date" },
+                          "content": "PLWABN|9810561542805606"
+                        },
+                        {
+                          "ns6:match": { "type": "suggested" },
+                          "content": "WKP|Q43375723"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "LC|n  87806607"
+                        },
+                        {
+                          "ns6:match": { "type": "lccn" },
+                          "content": "N6I|vtls000040077"
+                        },
+                        {
+                          "ns6:match": { "type": "double date" },
+                          "content": "CAOONL|ncf11670909"
+                        }
+                      ]
+                    },
+                    "ns6:sources": {
+                      "ns6:s": "J9U",
+                      "ns6:sid": "J9U|987007258412605171"
+                    }
+                  }
+                ]
+              },
+              "ns6:viafID": 100260729,
+              "ns6:dateType": "lived",
+              "ns6:sources": {
+                "ns6:source": [
+                  {
+                    "nsid": "0000000400231597",
+                    "content": "ISNI|0000000400231597"
+                  },
+                  {
+                    "nsid": 9810561542805606,
+                    "content": "PLWABN|9810561542805606"
+                  },
+                  { "nsid": "Q43375723", "content": "WKP|Q43375723" },
+                  { "nsid": "n87806607", "content": "LC|n  87806607" },
+                  { "nsid": "vtls000040077", "content": "N6I|vtls000040077" },
+                  { "nsid": "ncf11670909", "content": "CAOONL|ncf11670909" },
+                  {
+                    "nsid": 987007258412605171,
+                    "content": "J9U|987007258412605171"
+                  }
+                ]
+              },
+              "ns6:birthDate": 1827
+            }
+          }
         },
-                {
-          "@code": "f",
-          "#text": "1965"
+        {
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 6 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
+          },
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "ns7:VIAFCluster": {
+              "ns7:fixed": { "ns7:gender": "b" },
+              "ns7:nameType": "Personal",
+              "ns7:coauthors": {
+                "ns7:data": [
+                  {
+                    "ns7:text": "Ben\u00e9t, Stephen Vincent 1898-1943",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 4,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Brown, Sterling Wilson",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 3,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Allport, Gordon W. 1897-1967",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 3,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Zietlow, Carl F.",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 2,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Posselt, Eric 1892-",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 2,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Oper Frankfurt",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 2,
+                    "tag": 951
+                  },
+                  {
+                    "ns7:text": "Robson, William A. 1895-1980",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Manniche, Peter 1889-1981",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Frenzel, Herbert A. 1908-1995",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 1,
+                    "tag": 950
+                  },
+                  {
+                    "ns7:text": "Frankfurt am Main Amt f\u00fcr Wissenschaft und Kunst",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 1,
+                    "tag": 951
+                  }
+                ]
+              },
+              "ns7:dateType": "lived",
+              "ns7:titles": {
+                "ns7:work": [
+                  {
+                    "ns7:title": "America",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Amerika Geschichte der USA",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "britische Regierungssystem",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "D\u00e4nemark Ein soziales Versuchsfeld",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Kennedy in Bronze : die Entstehung einer Plastik = the creation of a bust",
+                    "ns7:sources": {
+                      "ns7:s": "BIBSYS",
+                      "ns7:sid": "BIBSYS|15008"
+                    }
+                  },
+                  {
+                    "ns7:title": "Knud Knudsen Skulpturen u. Bildnisse ; Ausstellung im Foyer d. Frankfurter Oper, 16. Januar - 15. Februar 1981",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "K\u00f6pfe ohne Maske 6 Plastiken und 6 Zeichnungen",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Lauter Sonderlinge Heitere u. nachdenkliche Erz.",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Liebesbrevier Ein Handb\u00fcchlein d. Lebensklugheit mit 350 alten u. neuen Lebensregeln ...",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Plastik zum Nachdenken",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Primer in intergroup relations",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Sammlung",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Treibjagd auf S\u00fcndenb\u00f6cke",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "\u00dcberwinde deine Vorurteile Wegweiser f\u00fcr d. Intergruppenarbeit",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Vorbilder, Zeitbilder, Sinnbilder Begegnungen mit Menschen und Problemen",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "Welt ohne Hass f\u00fchrende Wissenschaftler aller Fak. nehmen Stellung zu brennenden dt. Problemen; Aufs\u00e4tze u. Ansprachen z. I. Kongress \u00fcber Bessere Menschl. Beziehungen in M\u00fcnchen",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:title": "\"You are a traitor...\" / Knud Christian Knudsen// We survived : the stories of fourteen of the hidden and the hunted of Nazi Germany / as told to Eric H. Boehm. - New Haven, 1949. - S. [53]-[75].",
+                    "ns7:sources": {
+                      "ns7:s": "NUKAT",
+                      "ns7:sid": "NUKAT|n 2017026947"
+                    }
+                  },
+                  {
+                    "ns7:title": "zw\u00f6lf Temperamente Eine Figurenreihe z. Selbsterkenntnis u. Beurteilung anderer",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  }
+                ]
+              },
+              "ns7:publishers": {
+                "ns7:data": [
+                  {
+                    "ns7:text": "Christian-Verl.",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 11
+                  },
+                  {
+                    "ns7:text": "Pontes-Verl.",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 6
+                  },
+                  {
+                    "ns7:text": "Deutsche Nationalbibliothek",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 5
+                  },
+                  {
+                    "ns7:text": "Thiemig",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 4
+                  },
+                  {
+                    "ns7:text": "Europ\u00e4ische Verl.-Anst.",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 3
+                  },
+                  {
+                    "ns7:text": "Lippa-Fay Verl.",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 2
+                  },
+                  {
+                    "ns7:text": "Dezernat Kultur u. Freizeit",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 2
+                  },
+                  {
+                    "ns7:text": "Daco-Verl.",
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "count": 2
+                  },
+                  {
+                    "ns7:text": "Roether",
+                    "ns7:sources": {
+                      "ns7:s": "BIBSYS",
+                      "ns7:sid": "BIBSYS|15008"
+                    },
+                    "count": 1
+                  }
+                ]
+              },
+              "xmlns:ns7": "http://viaf.org/viaf/terms#",
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns7:history": {
+                "ns7:ht": [
+                  {
+                    "time": "2011-04-18T11:37:38+00:00",
+                    "type": "add",
+                    "recid": "DNB|118563823"
+                  },
+                  {
+                    "time": "2013-01-14T22:09:03+00:00",
+                    "type": "delete",
+                    "recid": "BIBSYS|x00015008"
+                  },
+                  {
+                    "time": "2013-09-16T16:15:07+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000117284474"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q15823959"
+                  },
+                  {
+                    "time": "2017-03-27T20:46:57.843233+00:00",
+                    "type": "add",
+                    "recid": "BIBSYS|15008"
+                  },
+                  {
+                    "time": "2017-09-11T15:51:49.868026+00:00",
+                    "type": "add",
+                    "recid": "NUKAT|n 2017026947"
+                  },
+                  {
+                    "time": "2017-09-11T17:37:20.965741+00:00",
+                    "type": "delete",
+                    "recid": "NUKAT|n 2006084891"
+                  }
+                ]
+              },
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns7:RelatorCodes": {
+                "ns7:data": [
+                  {
+                    "ns7:text": "ctb",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 16
+                  },
+                  {
+                    "ns7:text": "edt",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 2
+                  },
+                  {
+                    "ns7:text": "herausgeber",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 2
+                  },
+                  {
+                    "ns7:text": "ill",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 1
+                  },
+                  {
+                    "ns7:text": "illustrator",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 1
+                  },
+                  {
+                    "ns7:text": "mitwirkender",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 16
+                  }
+                ]
+              },
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns7:x500s": {
+                "ns7:x500": [
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Allport, Gordon W." },
+                        { "code": "d", "content": "1897-1967" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "allport gordon w 1897 1967",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "viafLink": 125509707,
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Bad Nauheim" },
+                        { "code": 4, "content": "ortw" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#placeOfActivity"
+                        }
+                      ],
+                      "ind2": " ",
+                      "ind1": " ",
+                      "dtype": "MARC21",
+                      "ns7:normalized": "bad nauheim",
+                      "tag": 551
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Ben\u00e9t, Stephen Vincent"
+                        },
+                        { "code": "d", "content": "1898-1943" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "benet stephen vincent 1898 1943",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "Brown, Sterling W."
+                      },
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "brown sterling w",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "viafLink": 142987052,
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Deutscher Koordinierungsrat der Christen und Juden"
+                        },
+                        { "code": 4, "content": "affi" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#affiliation"
+                        },
+                        { "code": "e", "content": "Affiliation" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 2,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "deutscher koordinierungsrat der christen und juden",
+                      "tag": 510
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Emmy" },
+                        { "code": "d", "content": "1888-1969" },
+                        { "code": 4, "content": "bezf" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#familialRelationship"
+                        },
+                        { "code": "e", "content": "Beziehung familiaer" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knudsen emmy 1888 1969",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Hans" },
+                        { "code": "d", "content": "1886-1971" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knudsen hans 1886 1971",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Hans" },
+                        { "code": "d", "content": "1886-1971" },
+                        { "code": 4, "content": "bezf" },
+                        {
+                          "code": 4,
+                          "content": "https://d-nb.info/standards/elementset/gnd#familialRelationship"
+                        },
+                        { "code": "e", "content": "Beziehung familiaer" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knudsen hans 1886 1971",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "viafLink": 64387302,
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "Manniche, Peter"
+                      },
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "manniche peter",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "viafLink": 22306253,
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "M\u00f6ssinger, Ingrid"
+                      },
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "mossinger ingrid",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Posselt, Eric" },
+                        { "code": "d", "content": "1892-" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "posselt eric 1892",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Robson, William A." },
+                        { "code": "d", "content": "1895-1980" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "robson william a 1895 1980",
+                      "tag": 500
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "Zietlow, Carl F."
+                      },
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "zietlow carl f",
+                      "tag": 500
+                    }
+                  }
+                ]
+              },
+              "ns7:deathDate": 1998,
+              "ns7:RecFormats": {
+                "ns7:data": [
+                  {
+                    "ns7:text": "aa",
+                    "ns7:sources": {
+                      "ns7:s": "NUKAT",
+                      "ns7:sid": "NUKAT|n 2017026947"
+                    },
+                    "count": 1
+                  },
+                  {
+                    "ns7:text": "am",
+                    "ns7:sources": {
+                      "ns7:s": ["BIBSYS", "DNB"],
+                      "ns7:sid": ["BIBSYS|15008", "DNB|118563823"]
+                    },
+                    "count": 28
+                  }
+                ]
+              },
+              "ns7:birthDate": "1916-01-16",
+              "ns7:sources": {
+                "ns7:source": [
+                  { "nsid": 15008, "content": "BIBSYS|15008" },
+                  {
+                    "nsid": "http://d-nb.info/gnd/118563823",
+                    "content": "DNB|118563823"
+                  },
+                  { "nsid": "Q15823959", "content": "WKP|Q15823959" },
+                  {
+                    "nsid": "0000000117284474",
+                    "content": "ISNI|0000000117284474"
+                  },
+                  { "nsid": "vtls015739929", "content": "NUKAT|n 2017026947" }
+                ]
+              },
+              "ns7:length": 270,
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns7:nationalityOfEntity": {
+                "ns7:data": [
+                  {
+                    "ns7:text": "DE",
+                    "ns7:sources": { "ns7:s": ["DNB", "WKP", "ISNI"] }
+                  },
+                  {
+                    "ns7:text": "DK",
+                    "ns7:sources": { "ns7:s": ["DNB", "ISNI"] }
+                  }
+                ]
+              },
+              "ns7:dates": {
+                "min": 194,
+                "max": 198,
+                "ns7:date": [
+                  { "scaled": 3.17, "count": 9, "content": 194 },
+                  { "scaled": 3.32, "count": 10, "content": 195 },
+                  { "scaled": 2.81, "count": 7, "content": 196 },
+                  { "scaled": 1, "count": 2, "content": 197 },
+                  { "scaled": 1, "count": 2, "content": 198 }
+                ]
+              },
+              "ns7:Document": {
+                "about": "http://viaf.org/viaf/167233446/",
+                "ns7:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/167233446"
+                },
+                "ns7:inDataset": { "resource": "http://viaf.org/viaf/data" }
+              },
+              "ns7:countries": {
+                "ns7:data": [
+                  {
+                    "scaled": 5,
+                    "ns7:text": "DE",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "count": 27
+                  },
+                  {
+                    "scaled": 1,
+                    "ns7:text": "US",
+                    "ns7:sources": {
+                      "ns7:s": "NUKAT",
+                      "ns7:sid": "NUKAT|n 2017026947"
+                    },
+                    "count": 1
+                  }
+                ]
+              },
+              "ns7:xLinks": {
+                "ns7:xLink": {
+                  "ns7:sources": { "ns7:s": "WKP", "ns7:sid": "WKP|Q15823959" },
+                  "type": "Wikipedia",
+                  "content": "https://de.wikipedia.org/wiki/Knud_Knudsen_(Bildhauer)"
+                }
+              },
+              "ns7:mainHeadings": {
+                "ns7:mainHeadingEl": [
+                  {
+                    "ns7:id": "ISNI|0000000117284474",
+                    "ns7:links": {
+                      "ns7:link": [
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "BIBSYS|15008"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "WKP|Q15823959"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "DNB|118563823"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "NUKAT|n 2017026947"
+                        }
+                      ]
+                    },
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "Knud Knudsen"
+                      },
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns7:id": "WKP|Q15823959",
+                    "ns7:links": {
+                      "ns7:link": [
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "BIBSYS|15008"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "DNB|118563823"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "NUKAT|n 2017026947"
+                        }
+                      ]
+                    },
+                    "ns7:sources": {
+                      "ns7:s": "WKP",
+                      "ns7:sid": "WKP|Q15823959"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knud Knudsen" },
+                        {
+                          "code": "c",
+                          "content": "deutscher Bildhauer, Verleger und Autor"
+                        },
+                        { "code": 9, "content": "de" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns7:id": "NUKAT|n 2017026947",
+                    "ns7:links": {
+                      "ns7:link": [
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "BIBSYS|15008"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "WKP|Q15823959"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "DNB|118563823"
+                        }
+                      ]
+                    },
+                    "ns7:sources": {
+                      "ns7:s": "NUKAT",
+                      "ns7:sid": "NUKAT|n 2017026947"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Knud Christian" },
+                        { "code": "d", "content": "(1916-1998)." }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns7:id": "BIBSYS|15008",
+                    "ns7:links": {
+                      "ns7:link": [
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "DNB|118563823"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "WKP|Q15823959"
+                        },
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "NUKAT|n 2017026947"
+                        }
+                      ]
+                    },
+                    "ns7:sources": {
+                      "ns7:s": "BIBSYS",
+                      "ns7:sid": "BIBSYS|15008"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Knud" },
+                        { "code": "d", "content": "1916-" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  },
+                  {
+                    "ns7:id": "DNB|118563823",
+                    "ns7:links": {
+                      "ns7:link": [
+                        {
+                          "ns7:match": { "type": "viafid" },
+                          "content": "BIBSYS|15008"
+                        },
+                        {
+                          "ns7:match": { "type": "suggested" },
+                          "content": "WKP|Q15823959"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "ISNI|0000000117284474"
+                        },
+                        {
+                          "ns7:match": { "type": "double date" },
+                          "content": "NUKAT|n 2017026947"
+                        }
+                      ]
+                    },
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Knud" },
+                        { "code": "d", "content": "1916-1998" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100
+                    }
+                  }
+                ],
+                "ns7:data": [
+                  {
+                    "ns7:text": "Knudsen, Knud 1916-1998",
+                    "ns7:sources": {
+                      "ns7:s": "DNB",
+                      "ns7:sid": "DNB|118563823"
+                    }
+                  },
+                  {
+                    "ns7:text": "Knud Knudsen",
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    }
+                  },
+                  {
+                    "ns7:text": "Knud Knudsen deutscher Bildhauer, Verleger und Autor",
+                    "ns7:sources": {
+                      "ns7:s": "WKP",
+                      "ns7:sid": "WKP|Q15823959"
+                    }
+                  },
+                  {
+                    "ns7:text": "Knudsen, Knud 1916-",
+                    "ns7:sources": {
+                      "ns7:s": "BIBSYS",
+                      "ns7:sid": "BIBSYS|15008"
+                    }
+                  },
+                  {
+                    "ns7:text": "Knudsen, Knud Christian (1916-1998).",
+                    "ns7:sources": {
+                      "ns7:s": "NUKAT",
+                      "ns7:sid": "NUKAT|n 2017026947"
+                    }
+                  }
+                ]
+              },
+              "ns7:viafID": 167233446,
+              "ns7:x400s": {
+                "ns7:x400": [
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "WKP",
+                      "ns7:sid": "WKP|Q15823959"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "Knud  Knudsen (1916-1998)"
+                      },
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knud knudsen 1916 1998",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": ["WKP", "ISNI"],
+                      "ns7:sid": ["WKP|Q15823959", "ISNI|0000000117284474"]
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knud Knudsen" },
+                        { "code": "c", "content": "Duits beeldhouwer (1916-)" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knud knudsen duits beeldhouwer 1916",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": ["WKP", "ISNI"],
+                      "ns7:sid": ["WKP|Q15823959", "ISNI|0000000117284474"]
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knud Knudsen" },
+                        {
+                          "code": "c",
+                          "content": "German sculptor and publisher"
+                        }
+                      ],
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knud knudsen german sculptor and publisher",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "ISNI",
+                      "ns7:sid": "ISNI|0000000117284474"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knud Knudsen" },
+                        {
+                          "code": "c",
+                          "content": "deutscher Bildhauer, verleger und Autor"
+                        }
+                      ],
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knud knudsen deutscher bildhauer verleger und autor",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Knud C." },
+                        { "code": "d", "content": "1916-1998" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knudsen knud c 1916 1998",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": ["ISNI", "DNB"],
+                      "ns7:sid": ["ISNI|0000000117284474", "DNB|118563823"]
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": [
+                        { "code": "a", "content": "Knudsen, Knud Christian" },
+                        { "code": "d", "content": "1916-1998" }
+                      ],
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "knudsen knud christian 1916 1998",
+                      "tag": 400
+                    }
+                  },
+                  {
+                    "ns7:sources": {
+                      "ns7:s": "WKP",
+                      "ns7:sid": "WKP|Q15823959"
+                    },
+                    "ns7:datafield": {
+                      "ns7:subfield": {
+                        "code": "a",
+                        "content": "\u30af\u30cc\u30fc\u30c8\u30fb\u30cc\u30fc\u30c9\u30bb\u30f3"
+                      },
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "ns7:normalized": "\u30af\u30cc\u30c8 \u30cc\u30c8\u30bb\u30f3",
+                      "tag": 400
+                    }
+                  }
+                ]
+              },
+              "ns7:ISBNs": {
+                "unique": 1,
+                "ns7:data": {
+                  "ns7:text": 9783521040434,
+                  "ns7:sources": { "ns7:s": "DNB", "ns7:sid": "DNB|118563823" },
+                  "count": 1
+                }
+              },
+              "ns7:creationtime": "2025-04-20T06:45:35.323188+00:00"
+            },
+            "xsi:type": "ns1:stringOrXmlFragment"
+          }
+        },
+        {
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 7 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
+          },
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "ns8:VIAFCluster": {
+              "ns8:birthDate": "1833-04-07",
+              "ns8:deathDate": "1888-04-18",
+              "ns8:titles": {
+                "ns8:work": [
+                  {
+                    "ns8:title": "Extract from the official reports on a series of comparative trials of water filtration",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "Introductory address on the opening of the twenty-sixth session of the Army Medical School, delivered at Netley, on April 2nd, 1873",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "Lectures on State Medicine delivered before the Society of Apothecaries at their hall in Blackfriars may and june 1875",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "Manual of practical hygiene, 1883:",
+                    "ns8:sources": {
+                      "ns8:sid": ["LC|no2015165840", "SUDOC|138546932"],
+                      "ns8:s": ["LC", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:title": "Military hygiene",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "On the pecuniary value of the emoluments and pensions of army medical officers",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "On the theory of ventilation : an attempt to establish a positive basis for the calculation of the amount of fresh air required for an inhabited air space",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "The Soldier's ration",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:title": "Supplementary note on the theory of ventilation",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  }
+                ]
+              },
+              "ns8:x400s": {
+                "ns8:x400": [
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont f s b f de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, F. S. B. F. de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont f s b francois de francis stephen benet francois 1833 1888",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Chaumont, F. S. B. Fran\u00e7ois de"
+                        },
+                        {
+                          "code": "q",
+                          "content": "(Francis Stephen Benet Fran\u00e7ois),"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "LC|no2015165840",
+                      "ns8:s": "LC"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont f s b francois de 1833 1888",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Chaumont, F. S. B. Fran\u00e7ois de"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont f de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, F. de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francis s b francois de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Francis S. B. Fran\u00e7ois de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francis s b francois de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Francis S. B. Fran\u00e7ois de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francis stephen bennet francois de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Francis Stephen Bennet Fran\u00e7ois de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francis stephen bennet francois de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Francis Stephen Bennet Fran\u00e7ois de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francis de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Francis de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francois de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Fran\u00e7ois de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "chaumont francois de",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Chaumont, Fran\u00e7ois de"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "de chaumont f s b f",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "De Chaumont, F. S. B. F."
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "de chaumont francis stephen bennet francois 1833 1888",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "De Chaumont, Francis Stephen Bennet Fran\u00e7ois,"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "LC|no2015165840",
+                      "ns8:s": "LC"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "ns8:normalized": "de chaumont francis stephen bennet francois 1833 1888",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "De Chaumont, Francis Stephen Bennet Fran\u00e7ois"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns8:normalized": "francis stephen chaumont",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Francis Stephen Chaumont"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "WKP|Q15982938"],
+                      "ns8:s": ["ISNI", "WKP"]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns8:normalized": "francis stephen de chaumont",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Francis Stephen de Chaumont"
+                      }
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns8:normalized": "francis stephen de chaumont brits chirurg 1833 1888",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Francis Stephen de Chaumont"
+                        },
+                        { "code": "c", "content": "Brits chirurg (1833-1888)" }
+                      ]
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "WKP|Q15982938",
+                      "ns8:s": "WKP"
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "ns8:normalized": "francis stephen de chaumont cirujano britanico",
+                      "dtype": "MARC21",
+                      "tag": 400,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Francis Stephen de Chaumont"
+                        },
+                        { "code": "c", "content": "cirujano brit\u00e1nico" }
+                      ]
+                    },
+                    "ns8:sources": {
+                      "ns8:sid": "WKP|Q15982938",
+                      "ns8:s": "WKP"
+                    }
+                  }
+                ]
+              },
+              "ns8:dates": {
+                "min": 187,
+                "max": 188,
+                "ns8:date": [
+                  { "scaled": 3.58, "count": 12, "content": 187 },
+                  { "scaled": 2.32, "count": 5, "content": 188 }
+                ]
+              },
+              "xmlns:ns8": "http://viaf.org/viaf/terms#",
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns8:languageOfEntity": {
+                "ns8:data": {
+                  "ns8:text": "eng",
+                  "ns8:sources": { "ns8:s": "LC" }
+                }
+              },
+              "ns8:history": {
+                "ns8:ht": [
+                  {
+                    "time": "2009-03-03T12:03:29+00:00",
+                    "type": "add",
+                    "recid": "DNB|116492856"
+                  },
+                  {
+                    "time": "2014-12-15T16:26:32+00:00",
+                    "type": "delete",
+                    "recid": "ISNI|0000000387721013"
+                  },
+                  {
+                    "time": "2014-12-15T16:26:32+00:00",
+                    "type": "add",
+                    "recid": "ISNI|0000000021383363"
+                  },
+                  {
+                    "time": "2015-04-14T18:56:54+00:00",
+                    "type": "add",
+                    "recid": "WKP|Q15982938"
+                  },
+                  {
+                    "time": "2016-02-13T18:33:30.924532+00:00",
+                    "type": "add",
+                    "recid": "LC|no2015165840"
+                  },
+                  {
+                    "time": "2019-03-06T13:32:26.519989+00:00",
+                    "type": "add",
+                    "recid": "SUDOC|138546932"
+                  },
+                  {
+                    "time": "2021-01-31T05:15:53.122767+00:00",
+                    "type": "add",
+                    "recid": "NTA|15648966X"
+                  },
+                  {
+                    "time": "2021-01-31T07:11:49.903177+00:00",
+                    "type": "delete",
+                    "recid": "NTA|105188042"
+                  }
+                ]
+              },
+              "ns8:RecFormats": {
+                "ns8:data": {
+                  "ns8:text": "am",
+                  "count": 13,
+                  "ns8:sources": {
+                    "ns8:sid": "SUDOC|138546932",
+                    "ns8:s": "SUDOC"
+                  }
+                }
+              },
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns8:Document": {
+                "about": "http://viaf.org/viaf/47514839/",
+                "ns8:inDataset": { "resource": "http://viaf.org/viaf/data" },
+                "ns8:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/47514839"
+                }
+              },
+              "ns8:RelatorCodes": {
+                "ns8:data": [
+                  {
+                    "ns8:text": "auteur",
+                    "count": 1,
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:text": "editeur scientifique",
+                    "count": 1,
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  }
+                ]
+              },
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#",
+              "ns8:coauthors": {
+                "ns8:data": [
+                  {
+                    "ns8:text": "Parkes, Edmund Alexander 1819-1876",
+                    "count": 4,
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    },
+                    "tag": 950
+                  },
+                  {
+                    "ns8:text": "Owen, Frederick N.",
+                    "count": 1,
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    },
+                    "tag": 950
+                  }
+                ]
+              },
+              "ns8:length": 202,
+              "ns8:countries": {
+                "ns8:data": {
+                  "ns8:text": "GB",
+                  "scaled": 4,
+                  "count": 11,
+                  "ns8:sources": {
+                    "ns8:sid": "SUDOC|138546932",
+                    "ns8:s": "SUDOC"
+                  }
+                }
+              },
+              "ns8:sources": {
+                "ns8:source": [
+                  {
+                    "nsid": "0000000021383363",
+                    "content": "ISNI|0000000021383363"
+                  },
+                  {
+                    "nsid": "http://d-nb.info/gnd/116492856",
+                    "content": "DNB|116492856"
+                  },
+                  { "nsid": "Q15982938", "content": "WKP|Q15982938" },
+                  { "nsid": "no2015165840", "content": "LC|no2015165840" },
+                  { "nsid": "15648966X", "content": "NTA|15648966X" },
+                  { "nsid": 138546932, "content": "SUDOC|138546932" }
+                ]
+              },
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "ns8:dateType": "lived",
+              "ns8:viafID": 47514839,
+              "ns8:nameType": "Personal",
+              "ns8:nationalityOfEntity": {
+                "ns8:data": [
+                  {
+                    "ns8:text": "FR",
+                    "ns8:sources": { "ns8:s": ["ISNI", "DNB"] }
+                  },
+                  {
+                    "ns8:text": "United Kingdom of Great Britain and Ireland",
+                    "ns8:sources": { "ns8:s": "WKP" }
+                  },
+                  { "ns8:text": "GB", "ns8:sources": { "ns8:s": "ISNI" } }
+                ]
+              },
+              "ns8:xLinks": {
+                "ns8:xLink": {
+                  "ns8:sources": { "ns8:sid": "WKP|Q15982938", "ns8:s": "WKP" },
+                  "type": "Wikipedia",
+                  "content": "https://en.wikipedia.org/wiki/Francis_de_Chaumont"
+                }
+              },
+              "ns8:mainHeadings": {
+                "ns8:mainHeadingEl": [
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Chaumont, Francis Stephen de"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:id": "ISNI|0000000021383363",
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    },
+                    "ns8:links": {
+                      "ns8:link": [
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "LC|no2015165840"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "DNB|116492856"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "WKP|Q15982938"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "SUDOC|138546932"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Chaumont, Francis Stephen \u0098de\u009c"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:id": "DNB|116492856",
+                    "ns8:sources": {
+                      "ns8:sid": "DNB|116492856",
+                      "ns8:s": "DNB"
+                    },
+                    "ns8:links": {
+                      "ns8:link": [
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "LC|no2015165840"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "WKP|Q15982938"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "SUDOC|138546932"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "De Chaumont, F. S. B. Fran\u00e7ois,"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:id": "LC|no2015165840",
+                    "ns8:sources": {
+                      "ns8:sid": "LC|no2015165840",
+                      "ns8:s": "LC"
+                    },
+                    "ns8:links": {
+                      "ns8:link": [
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "DNB|116492856"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "SUDOC|138546932"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "WKP|Q15982938"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "De Chaumont, Francis Stephen Bennet Fran\u00e7ois,"
+                        },
+                        { "code": "d", "content": "1833-1888" }
+                      ]
+                    },
+                    "ns8:id": "SUDOC|138546932",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    },
+                    "ns8:links": {
+                      "ns8:link": [
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "LC|no2015165840"
+                        },
+                        {
+                          "ns8:match": { "type": "double date" },
+                          "content": "DNB|116492856"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "WKP|Q15982938"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 0,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns8:subfield": [
+                        {
+                          "code": "a",
+                          "content": "Francis Stephen Bennet Fran\u00e7ois de Chaumont"
+                        },
+                        { "code": "c", "content": "British surgeon" },
+                        { "code": 9, "content": "en" }
+                      ]
+                    },
+                    "ns8:id": "WKP|Q15982938",
+                    "ns8:sources": {
+                      "ns8:sid": "WKP|Q15982938",
+                      "ns8:s": "WKP"
+                    },
+                    "ns8:links": {
+                      "ns8:link": [
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "LC|no2015165840"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "DNB|116492856"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "NTA|15648966X"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "SUDOC|138546932"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        },
+                        {
+                          "ns8:match": { "type": "suggested" },
+                          "content": "ISNI|0000000021383363"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "ns8:datafield": {
+                      "ind2": " ",
+                      "ind1": 1,
+                      "dtype": "MARC21",
+                      "tag": 100,
+                      "ns8:subfield": {
+                        "code": "a",
+                        "content": "Fran\u00e7ois de Chaumont, Francis Stephen Bennet"
+                      }
+                    },
+                    "ns8:id": "NTA|15648966X",
+                    "ns8:sources": {
+                      "ns8:sid": "NTA|15648966X",
+                      "ns8:s": "NTA"
+                    },
+                    "ns8:links": {
+                      "ns8:link": {
+                        "ns8:match": { "type": "suggested" },
+                        "content": "WKP|Q15982938"
+                      }
+                    }
+                  }
+                ],
+                "ns8:data": [
+                  {
+                    "ns8:text": "Chaumont, Francis Stephen \u0098de\u009c 1833-1888",
+                    "ns8:sources": {
+                      "ns8:sid": ["DNB|116492856", "ISNI|0000000021383363"],
+                      "ns8:s": ["DNB", "ISNI"]
+                    }
+                  },
+                  {
+                    "ns8:text": "De Chaumont, Francis Stephen Bennet Fran\u00e7ois, 1833-1888",
+                    "ns8:sources": {
+                      "ns8:sid": "SUDOC|138546932",
+                      "ns8:s": "SUDOC"
+                    }
+                  },
+                  {
+                    "ns8:text": "Francis Stephen Bennet Fran\u00e7ois de Chaumont British surgeon",
+                    "ns8:sources": {
+                      "ns8:sid": "WKP|Q15982938",
+                      "ns8:s": "WKP"
+                    }
+                  },
+                  {
+                    "ns8:text": "De Chaumont, F. S. B. Fran\u00e7ois, 1833-1888",
+                    "ns8:sources": {
+                      "ns8:sid": "LC|no2015165840",
+                      "ns8:s": "LC"
+                    }
+                  },
+                  {
+                    "ns8:text": "Fran\u00e7ois de Chaumont, Francis Stephen Bennet",
+                    "ns8:sources": {
+                      "ns8:sid": "NTA|15648966X",
+                      "ns8:s": "NTA"
+                    }
+                  }
+                ]
+              },
+              "ns8:creationtime": "2025-04-20T02:28:14.710284+00:00",
+              "ns8:publishers": {
+                "ns8:data": [
+                  {
+                    "ns8:text": "Oliver and Boyd",
+                    "count": 2,
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:text": "J. & A. Churchill",
+                    "count": 2,
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:text": "Harrison et Sons",
+                    "count": 2,
+                    "ns8:sources": {
+                      "ns8:sid": ["ISNI|0000000021383363", "SUDOC|138546932"],
+                      "ns8:s": ["ISNI", "SUDOC"]
+                    }
+                  },
+                  {
+                    "ns8:text": "Wood",
+                    "count": 1,
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  },
+                  {
+                    "ns8:text": "Smith Elder and Co",
+                    "count": 1,
+                    "ns8:sources": {
+                      "ns8:sid": "ISNI|0000000021383363",
+                      "ns8:s": "ISNI"
+                    }
+                  }
+                ]
+              },
+              "ns8:fixed": { "ns8:gender": "b" }
+            },
+            "xsi:type": "ns1:stringOrXmlFragment"
+          }
+        },
+        {
+          "recordPosition": { "xsi:type": "xsd:positiveInteger", "content": 8 },
+          "recordSchema": {
+            "xsi:type": "xsd:string",
+            "content": "http://viaf.org/VIAFCluster"
+          },
+          "xsi:type": "ns1:recordType",
+          "recordPacking": { "xsi:type": "xsd:string", "content": "xml" },
+          "recordData": {
+            "xsi:type": "ns1:stringOrXmlFragment",
+            "ns9:VIAFCluster": {
+              "ns9:Document": {
+                "ns9:inDataset": { "resource": "http://viaf.org/viaf/data" },
+                "about": "http://viaf.org/viaf/54942070/",
+                "ns9:primaryTopic": {
+                  "resource": "http://viaf.org/viaf/54942070"
+                }
+              },
+              "ns9:nationalityOfEntity": {
+                "ns9:data": {
+                  "ns9:sources": { "ns9:s": "DNB" },
+                  "ns9:text": "US"
+                }
+              },
+              "ns9:dateType": "lived",
+              "ns9:titles": "",
+              "ns9:nameType": "Personal",
+              "ns9:length": 10,
+              "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+              "xmlns:ns9": "http://viaf.org/viaf/terms#",
+              "ns9:history": {
+                "ns9:ht": {
+                  "time": "2012-11-27T04:00:16+00:00",
+                  "type": "add",
+                  "recid": "DNB|118658190"
+                }
+              },
+              "ns9:birthDate": 0,
+              "xmlns:void": "http://rdfs.org/ns/void#",
+              "xmlns": "http://viaf.org/viaf/terms#",
+              "ns9:sources": {
+                "ns9:source": {
+                  "nsid": "http://d-nb.info/gnd/118658190",
+                  "content": "DNB|118658190"
+                }
+              },
+              "ns9:viafID": 54942070,
+              "ns9:mainHeadings": {
+                "ns9:data": {
+                  "ns9:sources": { "ns9:sid": "DNB|118658190", "ns9:s": "DNB" },
+                  "ns9:text": "Bene\u0301t, Stephen"
+                },
+                "ns9:mainHeadingEl": {
+                  "ns9:sources": { "ns9:sid": "DNB|118658190", "ns9:s": "DNB" },
+                  "ns9:datafield": {
+                    "ind2": " ",
+                    "ind1": 1,
+                    "ns9:subfield": {
+                      "code": "a",
+                      "content": "Bene\u0301t, Stephen"
+                    },
+                    "dtype": "MARC21",
+                    "tag": 100
+                  },
+                  "ns9:id": "DNB|118658190"
+                }
+              },
+              "ns9:fixed": { "ns9:gender": "u" },
+              "ns9:creationtime": "2023-08-27T22:29:53.306060+00:00",
+              "xmlns:foaf": "http://xmlns.com/foaf/0.1/",
+              "ns9:deathDate": 0,
+              "xmlns:owl": "http://www.w3.org/2002/07/owl#"
+            }
+          }
         }
       ],
-      "normalized": "benet stephen vincent 1898 1943 historia sucinta de los estados unidos 1965"
+      "xsi:type": "ns1:recordsType"
     },
-    "sources":     {
-      "s": "XR",
-      "sid": "XR|VIAFEXP9613053"
-    }
-  }},
-  "birthDate": "0",
-  "deathDate": "0",
-  "dateType": "lived",
-  "languageOfEntity": {"data":   {
-    "text": "spa",
-    "sources": {"s": "XR"}
-  }},
-  "titles":   {
-    "author":     {
-      "@id": "VIAF|100260717",
-      "text": "Benét, Stephen Vincent"
+    "numberOfRecords": { "xsi:type": "xsd:nonNegativeInteger", "content": 8 },
+    "xsi:schemaLocation": "http://www.loc.gov/zing/srw/ http://www.loc.gov/standards/sru/sru1-1archive/xml-files/srw-types.xsd",
+    "resultSetIdleTime": { "xsi:type": "xsd:positiveInteger", "content": 1 },
+    "echoedSearchRetrieveRequest": {
+      "maximumRecords": { "xsi:type": "xsd:nonNegativeInteger", "content": 10 },
+      "xQuery": {
+        "ns11:searchClause": {
+          "ns11:term": { "xsi:type": "xsd:string", "content": "stephen benet" },
+          "ns11:relation": {
+            "ns11:value": { "xsi:type": "xsd:string", "content": "all" },
+            "xsi:type": "ns11:relationType"
+          },
+          "ns11:index": {
+            "xsi:type": "xsd:string",
+            "content": "local.personalNames"
+          },
+          "xsi:type": "ns11:searchClauseType",
+          "xmlns:ns11": "http://www.loc.gov/zing/cql/xcql/"
+        }
+      },
+      "recordSchema": { "xsi:type": "xsd:string", "content": "VIAF" },
+      "query": {
+        "xsi:type": "xsd:string",
+        "content": "local.personalNames all \"stephen benet\""
+      },
+      "xsi:type": "ns10:echoedSearchRetrieveRequestType",
+      "sortKeys": { "xsi:type": "xsd:string", "content": "holdingscount" },
+      "xmlns:ns10": "http://www.loc.gov/zing/srw/",
+      "version": { "xsi:type": "xsd:string", "content": 1.1 },
+      "recordPacking": { "xsi:type": "xsd:string", "content": "xml" }
     },
-    "work":     {
-      "@id": "VIAF|307979935",
-      "title": "America"
+    "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    "version": { "xsi:type": "xsd:string", "content": 1.1 },
+    "extraResponseData": {
+      "xsi:type": "ns12:extraDataType",
+      "xmlns:ns12": "http://www.loc.gov/zing/srw/",
+      "ns13:extraData": {
+        "xmlns": "http://oclc.org/srw/extraData",
+        "ns13:databaseTitle": "VIAF: The Virtual International Authority File",
+        "xmlns:ns13": "http://oclc.org/srw/extraData"
+      }
     }
-  },
-  "history": {"ht":   {
-    "@recid": "XR|VIAFEXP9613053",
-    "@time": "2015-02-16T15:07:12+00:00"
-  }},
-  "creationtime": "2017-08-13T09:16:57.090001+00:00"
+  }
 }
-            }}
-            
-        ]
-     }
-}
-    

--- a/viapy/tests/test_api.py
+++ b/viapy/tests/test_api.py
@@ -64,18 +64,16 @@ class TestViafAPI(object):
             # headers={'accept': 'application/json'},
             params={
                 "query": "stephen benet",
-                "httpAccept": "application/json",
-                "maximumRecords": 50,
-                "sortKeys": "holdingscount",
+                "maximumRecords": 10,
+                "sortKey": "holdingscount",
             },
+            headers={"Accept": "application/json"},
         )
 
         # sample empty result
         mockrequests.get.return_value.json.return_value = {
             "searchRetrieveResponse": {
-                "version": "1.1",
-                "numberOfRecords": "0",
-                "resultSetIdleTime": "1",
+                "numberOfRecords": {"content": "0"},
             }
         }
         results = viaf.search("stephen benet")
@@ -161,10 +159,10 @@ def test_sru_result():
     with open(sru_fixture) as srufile:
         sru_data = json.load(srufile)
     sru_res = SRUResult(sru_data)
-    assert sru_res.total_results == 13
+    assert sru_res.total_results == 8
     assert isinstance(sru_res.records, list)
     assert isinstance(sru_res.records[0], SRUItem)
-    assert len(sru_res.records) == 5
+    assert len(sru_res.records) == 8
 
 
 def test_sru_item():
@@ -173,17 +171,15 @@ def test_sru_item():
     with open(sru_fixture) as srufile:
         sru_data = json.load(srufile)
     sru_item = SRUResult(sru_data).records[0]
-    assert sru_item.uri == "http://viaf.org/viaf/888145424579886830405/"
-    assert sru_item.viaf_id == "888145424579886830405"
-    assert sru_item.nametype == "UniformTitleExpression"
-    assert (
-        sru_item.label
-        == "Benét, Stephen Vincent, 1898-1943. | John Brown's Body | Russian 1979"
-    )
+    assert sru_item.uri == "http://viaf.org/viaf/100260717/"
+    assert sru_item.viaf_id == 100260717
+    assert sru_item.nametype == "Personal"
 
     # label when data is a list
-    sru_item.recordData.mainHeadings.data = [sru_item.recordData.mainHeadings.data]
-    assert (
-        sru_item.label
-        == "Benét, Stephen Vincent, 1898-1943. | John Brown's Body | Russian 1979"
-    )
+    assert sru_item.label == "Bénet, Stephen Vincent, 1898-1943"
+
+    # label when data is a dict
+    sru_item.recordData.VIAFCluster.mainHeadings.data = {
+        "text": sru_item.recordData.VIAFCluster.mainHeadings.data[0].text
+    }
+    assert sru_item.label == "Bénet, Stephen Vincent, 1898-1943"

--- a/viapy/tests/test_api.py
+++ b/viapy/tests/test_api.py
@@ -1,6 +1,6 @@
 import json
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import requests
 import rdflib
@@ -123,13 +123,23 @@ class TestViafEntity(object):
         ent = ViafEntity(self.test_uri)
         assert ent.uriref == rdflib.URIRef(self.test_uri)
 
+    @patch("viapy.api.requests")
     @patch("viapy.api.rdflib")
-    def test_rdf(self, mockrdflib):
+    def test_rdf(self, mockrdflib, mockrequests):
+        mock_codes = Mock()
+        mock_codes.ok = 200
+        mockrequests.codes = mock_codes
+        mock_response = Mock()
+        mock_response.status_code = mock_codes.ok
+        mock_response.text = "data"
+        mockrequests.get.return_value = mock_response
         ent = ViafEntity(self.test_uri)
+        # should call requests.get on the uri, initialize a graph and parse data
         assert ent.rdf == mockrdflib.Graph.return_value
-        # should initialize a graph and parse uri data
         mockrdflib.Graph.assert_called_with()
-        mockrdflib.Graph.return_value.parse.assert_called_with(self.test_uri)
+        mockrequests.get.assert_called_with(self.test_uri, headers={"Accept": "application/rdf+xml"})
+        mockrdflib.Graph.return_value.parse.assert_called_with(data=mock_response.text, format="xml")
+        mockrequests.raise_for_status.assert_called_once
 
     def test_properties(self):
         # use viaf id matching fixture rdf file

--- a/viapy/tests/test_django.py
+++ b/viapy/tests/test_django.py
@@ -1,7 +1,8 @@
 # NOTE: these tests will only be run when django is installed
 import json
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
+from attrdict import AttrDict
 import pytest
 
 try:
@@ -104,12 +105,13 @@ class TestViews(TestCase):
         assert not data['results']
 
         viaf_id = '35247539'
-        mockresult = Mock(viaf_id=viaf_id,
-            uri='http://viaf.org/viaf/%s' % viaf_id,
-            label='Beach, Sylvia, 1887-1962',
-            nametype='personal')
-        mockresult.recordData.birthDate = 1887
-        mockresult.recordData.deathDate = 1962
+        mockresult = AttrDict({
+            'viaf_id': viaf_id,
+            'uri': 'http://viaf.org/viaf/%s' % viaf_id,
+            'label': 'Beach, Sylvia, 1887-1962',
+            'nametype': 'personal',
+            'recordData': {'VIAFCluster': {'birthDate': 1887, 'deathDate': 1962}},
+        })
 
         mockviafapi.return_value.search.return_value = [mockresult]
         result = self.client.get(search_url, {'q': 'sylvia beach'})
@@ -122,8 +124,8 @@ class TestViews(TestCase):
         assert item['id_number'] == mockresult.viaf_id
         assert item['text'] == mockresult.label
         assert item['nametype'] == mockresult.nametype
-        assert item['birth'] == mockresult.recordData.birthDate
-        assert item['death'] == mockresult.recordData.deathDate
+        assert item['birth'] == mockresult.recordData.VIAFCluster.birthDate
+        assert item['death'] == mockresult.recordData.VIAFCluster.deathDate
 
         # test search person
         person_search_url = reverse('viaf:person-search')

--- a/viapy/views.py
+++ b/viapy/views.py
@@ -62,8 +62,8 @@ class ViafSearch(autocomplete.Select2ListView):
                 text=item.label,
                 nametype=item.nametype,
                 # possibly useful to include, since we have them (for people)
-                birth=item.recordData.birthDate,
-                death=item.recordData.deathDate,
+                birth=item.recordData.VIAFCluster.birthDate,
+                death=item.recordData.VIAFCluster.deathDate,
             # exclude any names that are not personal
             ) for item in result]
         })


### PR DESCRIPTION
**Associated Issue(s):** #10

### Changes in this PR

- Update `ViafAPI.search`, `SRUResult`, and `SRUItem` for changes to the VIAF API's `/search` endpoint
   - Update unit tests and fixtures using a real-world response

### Notes

[API reference](https://developer.api.oclc.org/viaf-api)
- Changes to the search params and headers:
  - `maximumRecords` can only be a maximum of 10 (documented)
  - `sortKeys` has been renamed to `sortKey`, and only accepts `holdingscount` (documented)
  - `httpAccept`/`Accept` params no longer work, but passing an `Accept` header does (not documented)
- Changes to search results (none documented):
  - Search results are now nested as `records: { record: [] }` or `records: { record: {} }`
  - Metadata is now nested under `VIAFCluster` inside of `recordData`
  - Most JSON keys are now "namespaced" using `ns2:`, `ns3:`, `ns4:` prefixes, which increase per result. For example, a result's `recordData` might look like 
     ```json
     {"ns2:VIAFCluster": {"ns2:mainHeadings": {"ns2:data": {"ns2:text": "My Name"}}}}
     ```
     and the following search result will have the same keys but with `ns3:` prefixed, etc. up to `ns11`.
   - Other small things, like `numberOfRecords` count being nested under `content` now, and `@about` renamed to `about`


Tested in S&Co admin.