### PR TITLE
Feature/add precommit hooks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main, develop ]
+    branches: [main, develop]
   schedule:
     - cron: '34 21 * * 1'
 
@@ -17,40 +17,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: ['python']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,8 +12,6 @@ on:
   # normal behavior: run when a new release is created
   release:
     types: [published]
-  # allow running manually on main
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,19 +27,19 @@ jobs:
       name: pypi
       url: https://pypi.org/project/viapy/
     permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,6 @@ on:
     types: [published]
   # allow running manually on main
   workflow_dispatch:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv and Python version
-        uses: astral-sh/setup@v7
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           cp ci/testsettings.py testsettings.py
           uv run python -c "import uuid; print('SECRET_KEY = \'%s\'' % uuid.uuid4())" >> testsettings.py
+          realpath testsettings.py
 
       - name: Run pytest
         run: uv run pytest --cov=viapy --cov=tests --cov-report=xml --cov-report=term

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup test settings
         run: |
           cp ci/testsettings.py testsettings.py
-          python -c "import uuid; print('SECRET_KEY = \'%s\'' % uuid.uuid4())" >> testsettings.py
+          uv run python -c "import uuid; print('SECRET_KEY = \'%s\'' % uuid.uuid4())" >> testsettings.py
 
       - name: Run pytest
         run: uv run pytest --cov=viapy --cov=tests --cov-report=xml --cov-report=term

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: "${{ secrets.CODECOV_TOKEN }}"
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,13 +25,13 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install package dependencies
-        run: |
-          if [ "${{ matrix.django }}" -gt "0" ]
-          then
-            uv add django=="${{ matrix.django }}"
-            uv sync --extra test --extra django_test
+        run: >-
+          if [ "${{ matrix.django }}" -gt "0" ]; then
+            uv add django=="${{ matrix.django }}";
+            uv sync --extra test --extra django_test;
           else
-            uv sync --extra test
+            uv sync --extra test;
+          fi
 
       - name: Setup test settings
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,14 +26,12 @@ jobs:
 
       - name: Install package dependencies
         run: |
-          {
-            if [ "${{ matrix.django }}" -gt "0" ]
-            then
-              uv add django==${{ matrix.django }}
-              uv sync --extra test --extra django_test
-            else
-              uv sync --extra test
-          }
+          if [ "${{ matrix.django }}" -gt "0" ]
+          then
+            uv add django=="${{ matrix.django }}"
+            uv sync --extra test --extra django_test
+          else
+            uv sync --extra test
 
       - name: Setup test settings
         run: |
@@ -46,6 +44,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: "${{ secrets.CODECOV_TOKEN }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           cp ci/testsettings.py testsettings.py
           uv run python -c "import uuid; print('SECRET_KEY = \'%s\'' % uuid.uuid4())" >> testsettings.py
-          realpath testsettings.py
 
       - name: Run pytest
         run: uv run pytest --cov=viapy --cov=tests --cov-report=xml --cov-report=term

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,7 +3,7 @@ name: unit tests
 on:
   push: # run on all branches
   pull_request:
-    - branches: [develop, main]
+    branches: [develop, main]
   schedule: # run automatically on main branch each Tuesday at 11am
     - cron: "0 16 * * 2"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,20 @@ repos:
         additional_dependencies:
           - tomli
         exclude_types: ["css", "html", "javascript", "json"]
+  # Some out-of-the-box file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      # Check for files with merge conflict strings
+      - id: check-merge-conflict
+      # Verify syntax of TOML files
+      - id: check-toml
+      # Verify syntax of YAML files
+      - id: check-yaml
+        args: [--unsafe]
+      # Verifies that test files begin with test_
+      - id: name-tests-test
+        args: [--pytest-test-first]
+      # Removes trailing whitespace from all files
+      - id: trailing-whitespace
+        exclude: "docs/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# This config file specifies which pre-commit hooks to run.
+#
+# To set up, run `pre-commit install`
+# To run all hooks manually, run `pre-commit run --all-files`
+repos:
+  # Ruff Python linter and formatter (ruff configs in pyproject.toml)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
+    hooks:
+      # Run the linter
+      - id: ruff-check
+        args: [--fix, --show-fixes] # enable lint fixes
+      # Run the formatter
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,14 @@ repos:
       # Removes trailing whitespace from all files
       - id: trailing-whitespace
         exclude: "docs/"
+  # Check uv.lock file is up to date
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.8.6
+    hooks:
+      - id: uv-lock
+  # Validate GitHub Actions workflow files
+  - repo: https://github.com/mpalmer/action-validator
+    rev: v0.8.0
+    hooks:
+      - id: action-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # To set up, run `pre-commit install`
 # To run all hooks manually, run `pre-commit run --all-files`
 repos:
-  # Ruff Python linter and formatter (ruff configs in pyproject.toml)
+  # Ruff Python linter and formatter (configs in pyproject.toml)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.7
     hooks:
@@ -17,3 +17,11 @@ repos:
     rev: v0.17.2
     hooks:
       - id: yamlfmt
+  # Codespell for spell checking
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
+        exclude_types: ["css", "html", "javascript", "json"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,8 @@ repos:
         args: [--fix, --show-fixes] # enable lint fixes
       # Run the formatter
       - id: ruff-format
+  # yamlfmt for formatting YAML files
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.17.2
+    hooks:
+      - id: yamlfmt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ CHANGELOG
 * Handle negative years when parsing birth and death dates
 * Now tested on python 3.9 through 3.12
 * Now tested against Django 3.2 through 5.0
-* Migrate continous integration to GitHub Actions
+* Migrate continuous integration to GitHub Actions
 
 0.2
 ---

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ django-autocomplete-light lookup view and a VIAF url widget.
 
 .. image:: https://codecov.io/gh/Princeton-CDH/viapy/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/Princeton-CDH/viapy/branch/master
-    :alt: Code coverage  
+    :alt: Code coverage
 
 .. image:: https://www.codefactor.io/repository/github/princeton-cdh/viapy/badge
    :target: https://www.codefactor.io/repository/github/princeton-cdh/viapy
@@ -27,7 +27,7 @@ django-autocomplete-light lookup view and a VIAF url widget.
 
 .. image:: https://img.shields.io/pypi/pyversions/viapy
    :alt: PyPI - Python Version
-   
+
 .. image:: https://img.shields.io/pypi/djversions/viapy
    :alt: PyPI - Django Version
 
@@ -80,7 +80,7 @@ and a tool of your choice for creating python virtual environments
 
 Initial setup and installation:
 
-* Install ``uv`` if it's not installed. 
+* Install ``uv`` if it's not installed.
   It can be installed via PyPi, Homebrew, or a standalone installer.
   See uv's `installation documentation <https://docs.astral.sh/uv/getting-started/installation>`_
   for more details.

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -8,15 +8,14 @@ DATABASES = {
 
 INSTALLED_APPS = (
     # 'django.contrib.contenttypes',
-    'dal',
-    'dal_select2',
-    'viapy',
+    "dal",
+    "dal_select2",
+    "viapy",
 )
 
-ROOT_URLCONF = 'viapy.test_urls'
+ROOT_URLCONF = "viapy.test_urls"
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
 # must be added
 # SECRET_KEY = ''
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dev = [
 [dependency-groups]
 dev = ["viapy[dev]"]
 
-[tool.pytest]
+[tool.pytest.ini_options]
+# Need to use ini_options for Python 3.9
 testpaths = ["tests"]
 pythonpath = ["."]
 DJANGO_SETTINGS_MODULE = "testsettings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,13 @@ django = ["django>=3.2", "django-autocomplete-light"]
 django_test = ["pytest-django", "viapy[django]"]
 docs = ["sphinx"]
 test_all = ["viapy[test]", "viapy[django_test]"]
-dev = ["pre-commit", "viapy[django]", "viapy[test_all]", "viapy[docs]"]
+dev = [
+  "ruff",
+  "pre-commit",
+  "viapy[django]",
+  "viapy[test_all]",
+  "viapy[docs]"
+]
 
 [dependency-groups]
 dev = ["viapy[dev]"]
@@ -80,3 +86,19 @@ exclude_lines = [
 
 [tool.coverage.html]
 directory = "coverage_html_report"
+
+[tool.ruff.lint]
+# Include these rules in addition to ruff's defaults
+extend-select = [
+  "B",    # flake8-bugbear
+  "C4",   # flake8-comprehensions
+  "I",    #isort
+  "NPY",  # numpy-specific rules
+  "PERF", # perflint
+  "PTH",  # flake8-use-pathlib
+  "RUF",  # ruff-specific rules
+  "SIM",  # flake8-simplify
+  "UP",   # pyupgrade
+]
+# Can use to ignore specific rules within above selection
+ignore = []

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # viapy documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 12 17:06:23 2017.
@@ -15,22 +14,24 @@
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# documentation root, use pathlib.Path.resolve to make it absolute, like shown here.
 #
-# import os
+# import pathlib
 # import sys
-# sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, pathlib.Path().resolve())
 
 import os
+import pathlib
 import sys
+
 import django
 
-sys.path.insert(0, os.path.abspath("."))
+from viapy import __version__
+
+sys.path.insert(0, pathlib.Path().resolve())
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "docsettings"
 django.setup()
-
-from viapy import __version__
 
 
 # -- General configuration ------------------------------------------------

--- a/sphinx-docs/docsettings.py
+++ b/sphinx-docs/docsettings.py
@@ -8,14 +8,13 @@ DATABASES = {
 
 INSTALLED_APPS = (
     # 'django.contrib.contenttypes',
-    'dal',
-    'dal_select2',
-    'viapy',
+    "dal",
+    "dal_select2",
+    "viapy",
 )
 
-ROOT_URLCONF = 'viapy.test_urls'
+ROOT_URLCONF = "viapy.test_urls"
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-SECRET_KEY = 'f$J4FB3B=}1bFtJ$}b9s28Vsf?&otV}o0*V)g;#OD5%20uksel'
-
+SECRET_KEY = "f$J4FB3B=}1bFtJ$}b9s28Vsf?&otV}o0*V)g;#OD5%20uksel"

--- a/src/viapy/api.py
+++ b/src/viapy/api.py
@@ -2,12 +2,11 @@ import logging
 import re
 import time
 
+import rdflib
+import requests
 from attrdict import AttrMap
 from cached_property import cached_property
-import requests
-import rdflib
 from rdflib.namespace import Namespace
-
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +14,7 @@ logger = logging.getLogger(__name__)
 SCHEMA_NS = Namespace("http://schema.org/")
 
 
-class ViafAPI(object):
+class ViafAPI:
     """Wrapper for VIAF API.
 
     https://platform.worldcat.org/api-explorer/apis/VIAF
@@ -31,14 +30,14 @@ class ViafAPI(object):
     @classmethod
     def uri_from_id(cls, viaf_id):
         """Generate a canonical VIAF URI for the specified id"""
-        return "%s/%s" % (cls.uri_base, viaf_id)
+        return f"{cls.uri_base}/{viaf_id}"
 
     def suggest(self, term):
         """Query autosuggest API.  Returns a list of results, or an
         empty list if no suggestions are found or if something went wrong"""
 
         #  'viaf/AutoSuggest?query=[searchTerms]&callback[optionalCallbackName]
-        autosuggest_url = "%s/AutoSuggest" % self.api_base
+        autosuggest_url = f"{self.api_base}/AutoSuggest"
         response = requests.get(
             autosuggest_url,
             params={"query": term},
@@ -64,7 +63,7 @@ class ViafAPI(object):
         """Query VIAF seach interface.  Returns a list of :class:`SRUItem`
         :param query: CQL query in viaf syntax (e.g., ``cql.any all "term"``)
         """
-        search_url = "%s/search" % self.api_base
+        search_url = f"{self.api_base}/search"
         params = {
             "query": query,
             "maximumRecords": 10,  # TODO: configurable ?
@@ -73,7 +72,9 @@ class ViafAPI(object):
             "sortKey": "holdingscount",
         }
 
-        response = requests.get(search_url, params=params, headers={"Accept": "application/json"})
+        response = requests.get(
+            search_url, params=params, headers={"Accept": "application/json"}
+        )
         logger.debug(
             "search '%s': %s %s, %0.2f",
             params["query"],
@@ -90,7 +91,7 @@ class ViafAPI(object):
         response.raise_for_status()
 
     def _find_type(self, fltr, value):
-        return self.search('%s all "%s"' % (fltr, value))
+        return self.search(f'{fltr} all "{value}"')
 
     def find_person(self, name):
         """Search VIAF for local.personalNames"""
@@ -105,7 +106,7 @@ class ViafAPI(object):
         return self._find_type("local.geographicNames", name)
 
 
-class ViafEntity(object):
+class ViafEntity:
     """Object for working with a single VIAF entity.
 
     :param viaf_id: viaf identifier (either integer or uri)
@@ -177,7 +178,7 @@ class ViafEntity(object):
         return value
 
 
-class SRUResult(object):
+class SRUResult:
     """SRU search result object, for use with :meth:`ViafAPI.search`."""
 
     def __init__(self, data):
@@ -213,10 +214,11 @@ class SRUResult(object):
         else:
             return data
 
+
 class SRUItem(AttrMap):
     """Single item returned by a SRU search, for use with
     :meth:`ViafAPI.search` and :class:`SRUResult`.
-    
+
     The `VIAFCluster` attribute was added to each property lookup in 2025 to
     match updates to the /search API's JSON response."""
 

--- a/src/viapy/api.py
+++ b/src/viapy/api.py
@@ -60,7 +60,7 @@ class ViafAPI:
         return []
 
     def search(self, query):
-        """Query VIAF seach interface.  Returns a list of :class:`SRUItem`
+        """Query VIAF search interface.  Returns a list of :class:`SRUItem`
         :param query: CQL query in viaf syntax (e.g., ``cql.any all "term"``)
         """
         search_url = f"{self.api_base}/search"

--- a/src/viapy/test_urls.py
+++ b/src/viapy/test_urls.py
@@ -1,7 +1,7 @@
-"""Test URL configuration for viapy
-"""
+"""Test URL configuration for viapy"""
+
 try:
-    from django.urls import path, include
+    from django.urls import include, path
 
     from viapy import urls as viapy_urls
 

--- a/src/viapy/urls.py
+++ b/src/viapy/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from viapy.views import ViafLookup, ViafSearch
 
-
 app_name = "viapy"
 
 urlpatterns = [

--- a/src/viapy/views.py
+++ b/src/viapy/views.py
@@ -1,15 +1,15 @@
-from django.http import JsonResponse
 from dal import autocomplete
+from django.http import JsonResponse
 
 from viapy.api import ViafAPI
 
 
 class ViafLookup(autocomplete.Select2ListView):
-    '''View to provide VIAF suggestions for autocomplete lookup.
+    """View to provide VIAF suggestions for autocomplete lookup.
     Based on :class:`dal.autocompleteSelect2ListView`.  Expects search
     term as query string parameter `q`. Returns viaf URI as identifier
     and display form as text.
-    '''
+    """
 
     def get(self, request, *args, **kwargs):
         """Return JSON with suggested VIAF ids and display names."""
@@ -17,53 +17,64 @@ class ViafLookup(autocomplete.Select2ListView):
         result = viaf.suggest(self.q)
 
         # optionally filter by nametype if set
-        if 'nametype' in self.kwargs:
-            result = [item for item in result
-                       if item['nametype'] == self.kwargs['nametype']]
+        if "nametype" in self.kwargs:
+            result = [
+                item for item in result if item["nametype"] == self.kwargs["nametype"]
+            ]
 
-        return JsonResponse({
-            'results': [dict(
-                id=viaf.uri_from_id(item['viafid']),
-                id_number=item['viafid'],
-                text=item['displayForm'],
-                nametype=item['nametype']
-            # exclude any names that are not personal
-            ) for item in result]
-        })
+        return JsonResponse(
+            {
+                "results": [
+                    {
+                        "id": viaf.uri_from_id(item["viafid"]),
+                        "id_number": item["viafid"],
+                        "text": item["displayForm"],
+                        "nametype": item["nametype"],
+                        # exclude any names that are not personal
+                    }
+                    for item in result
+                ]
+            }
+        )
 
 
 class ViafSearch(autocomplete.Select2ListView):
-    '''View to provide VIAF suggestions for autocomplete lookup.
+    """View to provide VIAF suggestions for autocomplete lookup.
     Based on :class:`dal.autocompleteSelect2ListView`.  Expects search
     term as query string parameter `q`. Returns viaf URI as identifier
     and display form as text.
-    '''
+    """
 
     def get(self, request, *args, **kwargs):
         """Return JSON with suggested VIAF ids and display names."""
         viaf = ViafAPI()
 
         # search for specific kind of name if set
-        nametype = self.kwargs.get('nametype', None)
-        if nametype == 'personal':
+        nametype = self.kwargs.get("nametype", None)
+        if nametype == "personal":
             result = viaf.find_person(self.q)
         else:
             result = viaf.search(self.q)
 
         # check for empty search result and return empty json response
         if result is None:
-            return JsonResponse({'results': []})
+            return JsonResponse({"results": []})
 
-        return JsonResponse({
-            'results': [dict(
-                # id=viaf.uri_from_id(item.recordData.viafID),
-                id=item.uri,
-                id_number=item.viaf_id,
-                text=item.label,
-                nametype=item.nametype,
-                # possibly useful to include, since we have them (for people)
-                birth=item.recordData.VIAFCluster.birthDate,
-                death=item.recordData.VIAFCluster.deathDate,
-            # exclude any names that are not personal
-            ) for item in result]
-        })
+        return JsonResponse(
+            {
+                "results": [
+                    {
+                        # 'id': viaf.uri_from_id(item.recordData.viafID),
+                        "id": item.uri,
+                        "id_number": item.viaf_id,
+                        "text": item.label,
+                        "nametype": item.nametype,
+                        # possibly useful to include, since we have them (for people)
+                        "birth": item.recordData.VIAFCluster.birthDate,
+                        "death": item.recordData.VIAFCluster.deathDate,
+                        # exclude any names that are not personal
+                    }
+                    for item in result
+                ]
+            }
+        )

--- a/src/viapy/widgets.py
+++ b/src/viapy/widgets.py
@@ -11,8 +11,7 @@ class ViafWidget(autocomplete.Select2):
         # so when a value is set, add it to the list of choices
         if value:
             self.choices = [(value, value)]
-        widget = super(ViafWidget, self).render(name, value, attrs)
+        widget = super().render(name, value, attrs)
         return mark_safe(
-            '%s<p><br /><a id="viaf_uri" target="_blank" href="%s">%s</a></p>'
-            % (widget, value or "", value or "")
+            f'{widget}<p><br /><a id="viaf_uri" target="_blank" href="{value or ""}">{value or ""}</a></p>'
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,16 +1,16 @@
 import json
-import os
+import pathlib
 from unittest.mock import Mock, patch
 
-import requests
 import rdflib
+import requests
 
-from viapy.api import ViafAPI, ViafEntity, SRUResult, SRUItem
+from viapy.api import SRUItem, SRUResult, ViafAPI, ViafEntity
 
-FIXTURES_PATH = os.path.join(os.path.dirname(__file__), "fixtures")
+FIXTURES_PATH = pathlib.Path(__file__).parent / "fixtures"
 
 
-class TestViafAPI(object):
+class TestViafAPI:
     def test_get_uri(self):
         assert ViafAPI.uri_from_id("1234") == "http://viaf.org/viaf/1234"
         # numeric id should also work
@@ -51,8 +51,8 @@ class TestViafAPI(object):
         viaf = ViafAPI()
         mockrequests.codes = requests.codes
 
-        sru_fixture = os.path.join(FIXTURES_PATH, "sru_search.json")
-        with open(sru_fixture) as srufile:
+        sru_fixture = FIXTURES_PATH / "sru_search.json"
+        with sru_fixture.open() as srufile:
             mock_result = json.load(srufile)
         mockrequests.get.return_value.status_code = requests.codes.ok
         mockrequests.get.return_value.json.return_value = mock_result
@@ -85,7 +85,7 @@ class TestViafAPI(object):
         with patch.object(viaf, "search") as mocksearch:
             viaf.find_person(term)
 
-        mocksearch.assert_called_with('local.personalNames all "%s"' % term)
+        mocksearch.assert_called_with(f'local.personalNames all "{term}"')
 
     def test_find_corporate(self):
         viaf = ViafAPI()
@@ -93,7 +93,7 @@ class TestViafAPI(object):
         with patch.object(viaf, "search") as mocksearch:
             viaf.find_corporate(term)
 
-        mocksearch.assert_called_with('local.corporateNames all "%s"' % term)
+        mocksearch.assert_called_with(f'local.corporateNames all "{term}"')
 
     def test_find_place(self):
         viaf = ViafAPI()
@@ -101,13 +101,13 @@ class TestViafAPI(object):
         with patch.object(viaf, "search") as mocksearch:
             viaf.find_place(term)
 
-        mocksearch.assert_called_with('local.geographicNames all "%s"' % term)
+        mocksearch.assert_called_with(f'local.geographicNames all "{term}"')
 
 
-class TestViafEntity(object):
+class TestViafEntity:
     test_id = 102333412
     test_uri = "http://viaf.org/viaf/102333412"
-    rdf_fixture = os.path.join(FIXTURES_PATH, "102333412_rdf.xml")
+    rdf_fixture = FIXTURES_PATH / "102333412_rdf.xml"
 
     def test_init(self):
         # numeric id (either int or string should work)
@@ -137,9 +137,13 @@ class TestViafEntity(object):
         # should call requests.get on the uri, initialize a graph and parse data
         assert ent.rdf == mockrdflib.Graph.return_value
         mockrdflib.Graph.assert_called_with()
-        mockrequests.get.assert_called_with(self.test_uri, headers={"Accept": "application/rdf+xml"})
-        mockrdflib.Graph.return_value.parse.assert_called_with(data=mock_response.text, format="xml")
-        mockrequests.raise_for_status.assert_called_once
+        mockrequests.get.assert_called_with(
+            self.test_uri, headers={"Accept": "application/rdf+xml"}
+        )
+        mockrdflib.Graph.return_value.parse.assert_called_with(
+            data=mock_response.text, format="xml"
+        )
+        mock_response.raise_for_status.assert_called_once()
 
     def test_properties(self):
         # use viaf id matching fixture rdf file
@@ -165,8 +169,8 @@ class TestViafEntity(object):
 
 def test_sru_result():
     # test SRUResult class properties
-    sru_fixture = os.path.join(FIXTURES_PATH, "sru_search.json")
-    with open(sru_fixture) as srufile:
+    sru_fixture = FIXTURES_PATH / "sru_search.json"
+    with sru_fixture.open() as srufile:
         sru_data = json.load(srufile)
     sru_res = SRUResult(sru_data)
     assert sru_res.total_results == 8
@@ -177,8 +181,8 @@ def test_sru_result():
 
 def test_sru_item():
     # test SRUItem class
-    sru_fixture = os.path.join(FIXTURES_PATH, "sru_search.json")
-    with open(sru_fixture) as srufile:
+    sru_fixture = FIXTURES_PATH / "sru_search.json"
+    with sru_fixture.open() as srufile:
         sru_data = json.load(srufile)
     sru_item = SRUResult(sru_data).records[0]
     assert sru_item.uri == "http://viaf.org/viaf/100260717/"

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -2,8 +2,8 @@
 import json
 from unittest.mock import patch
 
-from attrdict import AttrDict
 import pytest
+from attrdict import AttrDict
 
 try:
     import django
@@ -19,120 +19,120 @@ except ImportError:
     from unittest import TestCase
 
 
-@pytest.mark.skipif(django is None, reason='Requires Django')
-class TestViafWidget(object):
-
+@pytest.mark.skipif(django is None, reason="Requires Django")
+class TestViafWidget:
     def test_render(self):
         widget = ViafWidget()
         # no value set - should not error
-        rendered = widget.render('person', None, {'id': 123})
-        assert '<p><br /><a id="viaf_uri" target="_blank" href=""></a></p>' \
-            in rendered
+        rendered = widget.render("person", None, {"id": 123})
+        assert '<p><br /><a id="viaf_uri" target="_blank" href=""></a></p>' in rendered
         # test marked as "safe"?
 
         # uri value set - should be included in generated link *and*
         # set as an option
-        uri = 'http://viaf.org/viaf/13103985/'
-        rendered = widget.render('person', uri, {'id': 1234})
-        assert '<a id="viaf_uri" target="_blank" href="%(uri)s">%(uri)s</a>' \
-            % {'uri': uri} in rendered
+        uri = "http://viaf.org/viaf/13103985/"
+        rendered = widget.render("person", uri, {"id": 1234})
+        assert f'<a id="viaf_uri" target="_blank" href="{uri}">{uri}</a>' in rendered
         # value should be set as an option to preserve existing
         # value when the form is submitted
-        assert '<option value="%(uri)s" selected>%(uri)s</option' % \
-            {'uri': uri} in rendered
+        assert f'<option value="{uri}" selected>{uri}</option' in rendered
 
 
-@pytest.mark.skipif(django is None, reason='Requires Django')
+@pytest.mark.skipif(django is None, reason="Requires Django")
 class TestViews(TestCase):
-
-    @patch('viapy.views.ViafAPI')
+    @patch("viapy.views.ViafAPI")
     def test_lookup(self, mockviafapi):
         # Sample of the dict passed by the api
-        mock_response = [{
-            'displayForm': 'Austen, Jane, 1775-1817',
-            'term': 'Austen, Jane, 1775-1817',
-            'viafid': '102333412',
-            'nametype': 'personal',
-        }]
+        mock_response = [
+            {
+                "displayForm": "Austen, Jane, 1775-1817",
+                "term": "Austen, Jane, 1775-1817",
+                "viafid": "102333412",
+                "nametype": "personal",
+            }
+        ]
         mockviafapi.return_value.suggest.return_value = mock_response
         # Get the actual URL from the API
         mockviafapi.return_value.uri_from_id = ViafAPI.uri_from_id
 
-        lookup_url = reverse('viaf:suggest')
-        result = self.client.get(lookup_url, {'q': 'austen'})
+        lookup_url = reverse("viaf:suggest")
+        result = self.client.get(lookup_url, {"q": "austen"})
         assert result.status_code == 200
         # Pull the JSON response in and break it down
         assert isinstance(result, JsonResponse)
-        data = json.loads(result.content.decode('utf-8'))
+        data = json.loads(result.content.decode("utf-8"))
         # Should be a list with at least one dictionary, if actual result
-        assert isinstance(data['results'], list)
-        assert isinstance(data['results'][0], dict)
+        assert isinstance(data["results"], list)
+        assert isinstance(data["results"][0], dict)
         # Now check for what needs to be in a dict to fill the autocomplete
-        data = data['results'][0]
-        assert data['id'] == 'http://viaf.org/viaf/102333412'
-        assert data['text'] == 'Austen, Jane, 1775-1817'
+        data = data["results"][0]
+        assert data["id"] == "http://viaf.org/viaf/102333412"
+        assert data["text"] == "Austen, Jane, 1775-1817"
 
-    @patch('viapy.views.ViafAPI')
+    @patch("viapy.views.ViafAPI")
     def test_person_lookup(self, mockviafapi):
-        person_lookup_url = reverse('viaf:person-suggest')
+        person_lookup_url = reverse("viaf:person-suggest")
         # test that non-personal names are filtered out
-        mock_response = [{
-            "term": "Jersey",
-            "displayForm": "Jersey",
-            "nametype": "geographic",
-            "lc": "n79086822",
-            "dnb": "000438200",
-            "selibr": "149410",
-            "bne": "xx5289012",
-            "viafid": "142485803",
-            "score": "2567",
-            "recordID": "142485803"
-        }]
+        mock_response = [
+            {
+                "term": "Jersey",
+                "displayForm": "Jersey",
+                "nametype": "geographic",
+                "lc": "n79086822",
+                "dnb": "000438200",
+                "selibr": "149410",
+                "bne": "xx5289012",
+                "viafid": "142485803",
+                "score": "2567",
+                "recordID": "142485803",
+            }
+        ]
         mockviafapi.return_value.suggest.return_value = mock_response
         mockviafapi.return_value.uri_from_id = ViafAPI.uri_from_id
-        result = self.client.get(person_lookup_url, {'q': 'jersey'})
+        result = self.client.get(person_lookup_url, {"q": "jersey"})
         # should return an empty list because no personal names were returned
-        data = json.loads(result.content.decode('utf-8'))
-        assert not data['results']
+        data = json.loads(result.content.decode("utf-8"))
+        assert not data["results"]
 
-
-    @patch('viapy.views.ViafAPI')
+    @patch("viapy.views.ViafAPI")
     def test_search(self, mockviafapi):
-        search_url = reverse('viaf:search')
+        search_url = reverse("viaf:search")
         # simulate no results
-        result = self.client.get(search_url, {'q': 'sylvia beach'})
-        data = json.loads(result.content.decode('utf-8'))
-        assert not data['results']
+        result = self.client.get(search_url, {"q": "sylvia beach"})
+        data = json.loads(result.content.decode("utf-8"))
+        assert not data["results"]
 
-        viaf_id = '35247539'
-        mockresult = AttrDict({
-            'viaf_id': viaf_id,
-            'uri': 'http://viaf.org/viaf/%s' % viaf_id,
-            'label': 'Beach, Sylvia, 1887-1962',
-            'nametype': 'personal',
-            'recordData': {'VIAFCluster': {'birthDate': 1887, 'deathDate': 1962}},
-        })
+        viaf_id = "35247539"
+        mockresult = AttrDict(
+            {
+                "viaf_id": viaf_id,
+                "uri": f"http://viaf.org/viaf/{viaf_id}",
+                "label": "Beach, Sylvia, 1887-1962",
+                "nametype": "personal",
+                "recordData": {"VIAFCluster": {"birthDate": 1887, "deathDate": 1962}},
+            }
+        )
 
         mockviafapi.return_value.search.return_value = [mockresult]
-        result = self.client.get(search_url, {'q': 'sylvia beach'})
-        mockviafapi.return_value.search.assert_called_with('sylvia beach')
-        data = json.loads(result.content.decode('utf-8'))
-        assert data['results']
-        assert len(data['results']) == 1
-        item = data['results'][0]
-        assert item['id'] == mockresult.uri
-        assert item['id_number'] == mockresult.viaf_id
-        assert item['text'] == mockresult.label
-        assert item['nametype'] == mockresult.nametype
-        assert item['birth'] == mockresult.recordData.VIAFCluster.birthDate
-        assert item['death'] == mockresult.recordData.VIAFCluster.deathDate
+        result = self.client.get(search_url, {"q": "sylvia beach"})
+        mockviafapi.return_value.search.assert_called_with("sylvia beach")
+        data = json.loads(result.content.decode("utf-8"))
+        assert data["results"]
+        assert len(data["results"]) == 1
+        item = data["results"][0]
+        assert item["id"] == mockresult.uri
+        assert item["id_number"] == mockresult.viaf_id
+        assert item["text"] == mockresult.label
+        assert item["nametype"] == mockresult.nametype
+        assert item["birth"] == mockresult.recordData.VIAFCluster.birthDate
+        assert item["death"] == mockresult.recordData.VIAFCluster.deathDate
 
         # test search person
-        person_search_url = reverse('viaf:person-search')
-        result = self.client.get(person_search_url, {'q': 'sylvia beach'})
-        mockviafapi.return_value.find_person.assert_called_with('sylvia beach')
+        person_search_url = reverse("viaf:person-search")
+        result = self.client.get(person_search_url, {"q": "sylvia beach"})
+        mockviafapi.return_value.find_person.assert_called_with("sylvia beach")
 
         # test empty search result
         mockviafapi.return_value.search.return_value = None
-        result = self.client.get(search_url, {'q': 'sylvia beach'})
+        result = self.client.get(search_url, {"q": "sylvia beach"})
         assert result.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -1148,6 +1148,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1459,6 +1484,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-django", version = "4.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-django", version = "4.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ruff" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -1537,6 +1563,7 @@ requires-dist = [
     { name = "pytest-django", marker = "extra == 'test-all'" },
     { name = "rdflib" },
     { name = "requests" },
+    { name = "ruff", marker = "extra == 'dev'" },
     { name = "sphinx", marker = "extra == 'dev'" },
     { name = "sphinx", marker = "extra == 'docs'" },
 ]

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,0 +1,5 @@
+# This is the config file for yamlfmt
+# For more details, see:
+#   https://github.com/google/yamlfmt/blob/main/docs/config-file.md 
+formatter:
+  retain_line_breaks_single: true

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,5 +1,5 @@
 # This is the config file for yamlfmt
 # For more details, see:
-#   https://github.com/google/yamlfmt/blob/main/docs/config-file.md 
+#   https://github.com/google/yamlfmt/blob/main/docs/config-file.md
 formatter:
   retain_line_breaks_single: true


### PR DESCRIPTION
**Associated Issue(s):** resolves #17 

### Changes in this PR

- Adds the following pre-commit hooks:
  - ruff linter and formatter
  - yamlfmt: YAML formatter
  - codespell
  - some out-of-the-box file checks
  - check uv.lock
  - validate GitHub Actions workflow files
- Adds ruff and pre-commit to dev dependencies
- Add yamlfmt.yml config file to retain linebreaks but only keep a single line in groups of many blank lines
- Add ruff rule set excluding type annotations and documentation
- Temporarily fixed pyproject.toml's pytest configuration to support Python 3.9 (intend to update when 3.9 support is dropped)
- Fixed unit test `TestViafEntity.test_rdf` within `test_api`
- Fixed broken GitHub Actions workflow  `unit_tests.yml`
- Fixed broken GitHub Actions workflow `python-publish.yml`
- Otherwise updated files according to pre-commit hooks

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

- I removed the option for running the `python-publish.yml` manually since there is no way to restrict to a specific branch.

### Reviewer Checklist

- [x] Verify that pytest can be run locally successfully
- [x] Confirm the file style changes look reasonable
